### PR TITLE
Add while, for, and foreach loop constructs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ lends itself to richer rule based engines, and similar domain specific problems,
 where your code needs to be more dynamic in nature than that which the CLR allows
 you to through C#, VB.NET or F#.
 
+The core library also includes basic flow control such as `if` branching and
+`while`, `for`, and `foreach` loops for simple iteration.
+
 ## What is a Symbolic Delegate?
 
 A Symbolic Delegate is a CLR delegate that is dynamically looked up during runtime

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -456,6 +456,48 @@ if(foo,{
 })
 ```
 
+In addition to branching with `if`, Lizzie also supports simple loops through
+the `while`, `for`, and `foreach` functions. The `while` function takes two
+lambdas; the first is evaluated before each iteration and as long as it returns
+a non-null value the second lambda, which is the body, will be executed. The
+`while` invocation yields the last value produced by the body, or `null` if the
+loop never executes.
+
+```javascript
+var(@i, 0)
+while({
+  lt(i, 3)
+}, {
+  set(@i, add(i, 1))
+})
+```
+
+The above example will loop until `i` is no longer less than `3`, returning `3`.
+
+The `for` function allows you to specify separate initialization, condition,
+iterator and body lambdas, mirroring a classic `for` loop.
+
+```javascript
+for({
+  var(@i, 0)
+}, {
+  lt(i, 3)
+}, {
+  set(@i, add(i, 1))
+}, {
+  i
+})
+```
+
+`foreach` iterates a list or map, binding each item to a symbol you supply and
+executing a body lambda for every element.
+
+```javascript
+foreach(@item, list(1,2,3), {
+  write(item)
+})
+```
+
 ### The definition of truth in Lizzie
 
 Lizzie does not have any explicit _"true"_ or _"false"_ boolean types or values.

--- a/lizzie.tests/For.cs
+++ b/lizzie.tests/For.cs
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2018 Thomas Hansen - thomas@gaiasoul.com
+ *
+ * Licensed under the terms of the MIT license, see the enclosed LICENSE
+ * file for details.
+ */
+
+using NUnit.Framework;
+
+namespace lizzie.tests
+{
+    public class For
+    {
+        [Test]
+        public void ConditionInitiallyFalse()
+        {
+            var lambda = LambdaCompiler.Compile(@"for({
+  var(@i, 0)
+}, {
+  null
+}, {
+  set(@i, add(i, 1))
+}, {
+  i
+})");
+            var result = lambda();
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void IteratesUntilConditionIsNull()
+        {
+            var lambda = LambdaCompiler.Compile(@"for({
+  var(@i, 0)
+}, {
+  lt(i, 3)
+}, {
+  set(@i, add(i, 1))
+}, {
+  i
+})");
+            var result = lambda();
+            Assert.AreEqual(2, result);
+        }
+    }
+}

--- a/lizzie.tests/Foreach.cs
+++ b/lizzie.tests/Foreach.cs
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2018 Thomas Hansen - thomas@gaiasoul.com
+ *
+ * Licensed under the terms of the MIT license, see the enclosed LICENSE
+ * file for details.
+ */
+
+using NUnit.Framework;
+
+namespace lizzie.tests
+{
+    public class Foreach
+    {
+        [Test]
+        public void EmptyListReturnsNull()
+        {
+            var lambda = LambdaCompiler.Compile(@"foreach(@item, list(), {
+  item
+})");
+            var result = lambda();
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void IteratesOverList()
+        {
+            var lambda = LambdaCompiler.Compile(@"foreach(@item, list(1,2,3), {
+  item
+})");
+            var result = lambda();
+            Assert.AreEqual(3, result);
+        }
+    }
+}

--- a/lizzie.tests/While.cs
+++ b/lizzie.tests/While.cs
@@ -1,0 +1,40 @@
+﻿/*
+ * Copyright (c) 2018 Thomas Hansen - thomas@gaiasoul.com
+ *
+ * Licensed under the terms of the MIT license, see the enclosed LICENSE
+ * file for details.
+ */
+
+using NUnit.Framework;
+
+namespace lizzie.tests
+{
+    public class While
+    {
+        [Test]
+        public void ConditionInitiallyFalse()
+        {
+            var lambda = LambdaCompiler.Compile(@"while({
+  null
+}, {
+  57
+})");
+            var result = lambda();
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void IteratesUntilConditionIsNull()
+        {
+            var lambda = LambdaCompiler.Compile(@"var(@i,0)
+while({
+  lt(i, 3)
+}, {
+  set(@i, add(i, 1))
+})");
+            var result = lambda();
+            Assert.AreEqual(3, result);
+        }
+    }
+}
+

--- a/lizzie/Functions.cs
+++ b/lizzie/Functions.cs
@@ -369,6 +369,142 @@ namespace lizzie
         });
 
         /// <summary>
+        /// Repeatedly evaluates a lambda as long as a condition returns a non-null value.
+        ///
+        /// Expects exactly two arguments; the first is a lambda evaluated before each
+        /// iteration to determine if the loop should continue, and the second is a lambda
+        /// representing the body of the loop. The last value produced by the body is
+        /// returned, or null if the body never executes.
+        /// </summary>
+        /// <value>The function wrapping the 'while keyword'.</value>
+        public static Function<TContext> While => new Function<TContext>((ctx, binder, arguments) =>
+        {
+            if (arguments.Count != 2)
+                throw new LizzieRuntimeException("The 'while' keyword expects exactly 2 arguments.");
+
+            var condition = arguments.Get(0) as Function<TContext>;
+            if (condition == null)
+                throw new LizzieRuntimeException("The 'while' keyword requires a lambda argument as its first argument.");
+
+            var body = arguments.Get(1) as Function<TContext>;
+            if (body == null)
+                throw new LizzieRuntimeException("The 'while' keyword requires a lambda argument as its second argument.");
+
+            object result = null;
+            while (condition(ctx, binder, arguments) != null)
+            {
+                result = body(ctx, binder, arguments);
+            }
+            return result;
+        });
+
+        /// <summary>
+        /// Repeatedly executes a body lambda while a condition returns a non-null value.
+        /// An initialization lambda runs once before the first evaluation and an iterator
+        /// lambda runs after each iteration.
+        ///
+        /// Expects exactly four arguments; initialization, condition, iterator and body
+        /// lambdas respectively. Returns the last value produced by the body, or null if
+        /// the loop never executes.
+        /// </summary>
+        /// <value>The function wrapping the 'for keyword'.</value>
+        public static Function<TContext> For => new Function<TContext>((ctx, binder, arguments) =>
+        {
+            if (arguments.Count != 4)
+                throw new LizzieRuntimeException("The 'for' keyword expects exactly 4 arguments.");
+
+            var init = arguments.Get(0) as Function<TContext>;
+            if (init == null)
+                throw new LizzieRuntimeException("The 'for' keyword requires a lambda argument as its first argument.");
+
+            var condition = arguments.Get(1) as Function<TContext>;
+            if (condition == null)
+                throw new LizzieRuntimeException("The 'for' keyword requires a lambda argument as its second argument.");
+
+            var iterator = arguments.Get(2) as Function<TContext>;
+            if (iterator == null)
+                throw new LizzieRuntimeException("The 'for' keyword requires a lambda argument as its third argument.");
+
+            var body = arguments.Get(3) as Function<TContext>;
+            if (body == null)
+                throw new LizzieRuntimeException("The 'for' keyword requires a lambda argument as its fourth argument.");
+
+            // Execute initialization once.
+            init(ctx, binder, arguments);
+
+            object result = null;
+            while (condition(ctx, binder, arguments) != null)
+            {
+                result = body(ctx, binder, arguments);
+                iterator(ctx, binder, arguments);
+            }
+            return result;
+        });
+
+        /// <summary>
+        /// Iterates a list or map, evaluating a body lambda for each item. The first
+        /// argument must be a symbol used to reference the current item inside the
+        /// body. The second argument must be the list or map to iterate and the third
+        /// argument must be the body lambda. Returns the last value produced by the
+        /// body, or null if the sequence is empty.
+        /// </summary>
+        /// <value>The function wrapping the 'foreach keyword'.</value>
+        public static Function<TContext> Foreach => new Function<TContext>((ctx, binder, arguments) =>
+        {
+            if (arguments.Count < 3)
+                throw new LizzieRuntimeException("The 'foreach' keyword requires 3 arguments, and you tried to invoke it with fewer.");
+
+            var argName = arguments.Get(0) as string;
+            if (argName == null)
+                throw new LizzieRuntimeException("The 'foreach' function must be given a symbol name as its first argument.");
+            if (binder.ContainsDynamicKey(argName))
+                throw new LizzieRuntimeException($"The '{argName}' is already declared from before, hence you can't use it as an iterator for the 'foreach' function.");
+
+            var body = arguments.Get(2) as Function<TContext>;
+            if (body == null)
+                throw new LizzieRuntimeException("When invoking the 'foreach' function, the third argument must be a lambda object, e.g. '{ ... some code ... }'.");
+
+            object result = null;
+            if (arguments.Get(1) is List<object> list)
+            {
+                try
+                {
+                    foreach (var ix in list)
+                    {
+                        binder[argName] = ix;
+                        result = body(ctx, binder, arguments);
+                    }
+                }
+                finally
+                {
+                    if (binder.ContainsDynamicKey(argName))
+                        binder.RemoveKey(argName);
+                }
+            }
+            else if (arguments.Get(1) is Dictionary<string, object> map)
+            {
+                try
+                {
+                    foreach (var ix in map.Keys)
+                    {
+                        binder[argName] = ix;
+                        result = body(ctx, binder, arguments);
+                    }
+                }
+                finally
+                {
+                    if (binder.ContainsDynamicKey(argName))
+                        binder.RemoveKey(argName);
+                }
+            }
+            else
+            {
+                throw new LizzieRuntimeException("The 'foreach' function must be given either a 'map' or a 'list' as its 2nd argument.");
+            }
+            return result;
+        });
+
+        /// <summary>
         /// Creates an equals function, that checks two or more objects for equality.
         ///
         /// This function will return null if any of the objects it is being asked

--- a/lizzie/LambdaCompiler.cs
+++ b/lizzie/LambdaCompiler.cs
@@ -105,6 +105,11 @@ namespace lizzie
             binder["lte"] = Functions<TContext>.Lte;
             binder["not"] = Functions<TContext>.Not;
 
+            // Loop functions.
+            binder["while"] = Functions<TContext>.While;
+            binder["for"] = Functions<TContext>.For;
+            binder["foreach"] = Functions<TContext>.Foreach;
+
             // Boolean algebraic functions.
             binder["any"] = Functions<TContext>.Any;
             binder["all"] = Functions<TContext>.All;


### PR DESCRIPTION
## Summary
- add `for` loop function with initialization, condition, iterator, and body lambdas
- add `foreach` loop function for iterating lists or maps
- register loop functions in the default binder
- document `for` and `foreach` usage and mention in README
- cover loop semantics with tests

## Testing
- `dotnet test` *(fails: Framework 'Microsoft.NETCore.App', version '2.0.0' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b33dabbb20832b9917094443959cca