### PR TITLE
Add try/catch/finally control function

### DIFF
--- a/lizzie.tests/For.cs
+++ b/lizzie.tests/For.cs
@@ -19,7 +19,7 @@ namespace lizzie.tests
 }, {
   null
 }, {
-  set(@i, add(i, 1))
+  set(@i, +(i, 1))
 }, {
   i
 })");
@@ -35,7 +35,7 @@ namespace lizzie.tests
 }, {
   lt(i, 3)
 }, {
-  set(@i, add(i, 1))
+  set(@i, +(i, 1))
 }, {
   i
 })");

--- a/lizzie.tests/Try.cs
+++ b/lizzie.tests/Try.cs
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2018 Thomas Hansen - thomas@gaiasoul.com
+ *
+ * Licensed under the terms of the MIT license, see the enclosed LICENSE
+ * file for details.
+ */
+
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace lizzie.tests
+{
+    public class Try
+    {
+        [Test]
+        public void TryWithoutExceptionExecutesFinally()
+        {
+            var lambda = LambdaCompiler.Compile(@"
+var(@catchFlag)
+var(@finallyFlag)
+var(@result, try({
+  57
+}, function({
+  set(@catchFlag, 1)
+  67
+}, @ex), {
+  set(@finallyFlag, 1)
+}))
+list(result, finallyFlag, catchFlag)
+");
+            var list = lambda() as List<object>;
+            Assert.AreEqual(57, list[0]);
+            Assert.AreEqual(1, list[1]);
+            Assert.IsNull(list[2]);
+        }
+
+        [Test]
+        public void TryCatchReceivesExceptionAndFinallyRuns()
+        {
+            var lambda = LambdaCompiler.Compile(@"
+var(@finallyFlag)
+var(@catchMsg)
+var(@result, try({
+  +(1)
+}, function({
+  set(@catchMsg, string(ex))
+  67
+}, @ex), {
+  set(@finallyFlag, 1)
+}))
+list(result, finallyFlag, catchMsg)
+");
+            var list = lambda() as List<object>;
+            Assert.AreEqual(67, list[0]);
+            Assert.AreEqual(1, list[1]);
+            StringAssert.Contains("The 'add' keyword", list[2] as string);
+        }
+    }
+}
+

--- a/lizzie.tests/While.cs
+++ b/lizzie.tests/While.cs
@@ -30,7 +30,7 @@ namespace lizzie.tests
 while({
   lt(i, 3)
 }, {
-  set(@i, add(i, 1))
+  set(@i, +(i, 1))
 })");
             var result = lambda();
             Assert.AreEqual(3, result);

--- a/lizzie/LambdaCompiler.cs
+++ b/lizzie/LambdaCompiler.cs
@@ -106,6 +106,7 @@ namespace lizzie
             binder["not"] = Functions<TContext>.Not;
 
             // Loop functions.
+            binder["try"] = Functions<TContext>.Try;
             binder["while"] = Functions<TContext>.While;
             binder["for"] = Functions<TContext>.For;
             binder["foreach"] = Functions<TContext>.Foreach;


### PR DESCRIPTION
## Summary
- add Try control function to support try/catch/finally semantics
- register `try` in the language binder
- add unit tests and adjust existing loop tests for numeric addition

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b346e18f0c832bad360c0674d19c7b