### PR TITLE
Replace legacy asserts with NUnit4 Assert.That

### DIFF
--- a/lizzie.tests/Binder.cs
+++ b/lizzie.tests/Binder.cs
@@ -18,12 +18,12 @@ namespace lizzie.tests
             var original = new Binder<SimpleValues>();
             var clone = original.Clone();
             foreach (var ix in original.StaticItems) {
-                Assert.AreEqual(clone[ix], original[ix]);
+                Assert.That(original[ix], Is.EqualTo(clone[ix]));
             }
             foreach (var ix in clone.StaticItems) {
-                Assert.AreEqual(clone[ix], original[ix]);
+                Assert.That(original[ix], Is.EqualTo(clone[ix]));
             }
-            Assert.AreEqual(0, clone.StackCount);
+            Assert.That(clone.StackCount, Is.EqualTo(0));
         }
 
         [Test]
@@ -36,15 +36,15 @@ namespace lizzie.tests
             original["bar"] = 77;
             var clone = original.Clone();
             foreach (var ix in original.StaticItems) {
-                Assert.AreEqual(clone[ix], original[ix]);
+                Assert.That(original[ix], Is.EqualTo(clone[ix]));
             }
             foreach (var ix in clone.StaticItems) {
-                Assert.AreEqual(clone[ix], original[ix]);
+                Assert.That(original[ix], Is.EqualTo(clone[ix]));
             }
-            Assert.AreEqual(2, clone.StackCount);
-            Assert.AreEqual(77, clone["bar"]);
+            Assert.That(clone.StackCount, Is.EqualTo(2));
+            Assert.That(clone["bar"], Is.EqualTo(77));
             clone.PopStack();
-            Assert.AreEqual(57, clone["foo"]);
+            Assert.That(clone["foo"], Is.EqualTo(57));
         }
 
         [Test]
@@ -52,7 +52,7 @@ namespace lizzie.tests
         {
             var lambda = LambdaCompiler.Compile(new SimpleValues(), "get-static()");
             var result = lambda();
-            Assert.AreEqual(7, result);
+            Assert.That(result, Is.EqualTo(7));
         }
 
         class SimpleValueExtended : SimpleValues
@@ -84,7 +84,7 @@ namespace lizzie.tests
             } catch {
                 error = true;
             }
-            Assert.AreEqual(true, error);
+            Assert.That(error, Is.True);
         }
 
         [Test]
@@ -93,7 +93,7 @@ namespace lizzie.tests
             SimpleValues simple = new SimpleValueExtended();
             var lambda = LambdaCompiler.Compile(simple, "extended-function(20)", true);
             var result = lambda();
-            Assert.AreEqual(77, result);
+            Assert.That(result, Is.EqualTo(77));
         }
 
         [Test]
@@ -102,7 +102,7 @@ namespace lizzie.tests
             SimpleValues simple = new SimpleValueExtended();
             var lambda = LambdaCompiler.Compile(simple, "+(get-constant-integer-2(), extended-function(3))", true);
             var result = lambda();
-            Assert.AreEqual(117, result);
+            Assert.That(result, Is.EqualTo(117));
         }
 
         [Test]
@@ -111,7 +111,7 @@ namespace lizzie.tests
             SimpleValues simple = new SimpleValueExtended();
             var lambda = LambdaCompiler.Compile(simple, "+(get-constant-integer(), extended-function(3))", true);
             var result = lambda();
-            Assert.AreEqual(117, result);
+            Assert.That(result, Is.EqualTo(117));
         }
 
         [Test]
@@ -120,7 +120,7 @@ namespace lizzie.tests
             SimpleValues simple = new SimpleValueExtended();
             var lambda = LambdaCompiler.Compile(simple, "+(get-static(), extended-function(20))", true);
             var result = lambda();
-            Assert.AreEqual(84, result);
+            Assert.That(result, Is.EqualTo(84));
         }
 
         [Test]
@@ -129,7 +129,7 @@ namespace lizzie.tests
             SimpleValues simple = new SimpleValueDoubleExtended();
             var lambda = LambdaCompiler.Compile(simple, "+(get-static(), extended-function(20), extended-function-2(3))", true);
             var result = lambda();
-            Assert.AreEqual(90, result);
+            Assert.That(result, Is.EqualTo(90));
         }
 
         class BaseClass1
@@ -156,7 +156,7 @@ namespace lizzie.tests
             BaseClass1 simple = new SuperClass1();
             var lambda = LambdaCompiler.Compile(simple, "foo()", true);
             var result = lambda();
-            Assert.AreEqual(77, result);
+            Assert.That(result, Is.EqualTo(77));
         }
 
         class BaseClass2
@@ -183,7 +183,7 @@ namespace lizzie.tests
             BaseClass2 simple = new SuperClass2();
             var lambda = LambdaCompiler.Compile(simple, "+(foo1(), foo2())", true);
             var result = lambda();
-            Assert.AreEqual(57, result);
+            Assert.That(result, Is.EqualTo(57));
         }
 
         class BaseClass3
@@ -231,7 +231,7 @@ namespace lizzie.tests
             BaseClass3 simple = new SuperClass3_2();
             var lambda = LambdaCompiler.Compile(simple, "+(foo1(), foo2(), foo3(), foo4(),foo5())", true);
             var result = lambda();
-            Assert.AreEqual(67, result);
+            Assert.That(result, Is.EqualTo(67));
         }
 
         [Test]
@@ -239,7 +239,7 @@ namespace lizzie.tests
         {
             SimpleValues simple = new SimpleValueDoubleExtended();
             var binder = new Binder<SimpleValues>(simple);
-            Assert.AreEqual(true, binder.DeeplyBound);
+            Assert.That(binder.DeeplyBound, Is.True);
         }
 
         [Test]
@@ -247,7 +247,7 @@ namespace lizzie.tests
         {
             SimpleValues simple = new SimpleValues();
             var binder = new Binder<SimpleValues>();
-            Assert.AreEqual(false, binder.DeeplyBound);
+            Assert.That(binder.DeeplyBound, Is.False);
         }
 
         [Test]
@@ -272,7 +272,7 @@ my-func()
             lambda();
 
             // Verifying instance is NOT deeply bound!
-            Assert.AreEqual(false, binder.DeeplyBound);
+            Assert.That(binder.DeeplyBound, Is.False);
         }
 
         [Test]
@@ -300,7 +300,7 @@ my-func()
             } catch {
                 success = true;
             }
-            Assert.AreEqual(true, success);
+            Assert.That(success, Is.True);
         }
     }
 }

--- a/lizzie.tests/Branching.cs
+++ b/lizzie.tests/Branching.cs
@@ -22,7 +22,7 @@ if(foo, {
 })
 ");
             var result = lambda();
-            Assert.AreEqual(57, result);
+            Assert.That(result, Is.EqualTo(57));
         }
 
         [Test]
@@ -35,7 +35,7 @@ if(foo, {
 })
 ");
             var result = lambda();
-            Assert.IsNull(result);
+            Assert.That(result, Is.Null);
         }
 
         [Test]
@@ -50,7 +50,7 @@ if(@foo(), {
 })
 ");
             var result = lambda();
-            Assert.AreEqual(57, result);
+            Assert.That(result, Is.EqualTo(57));
         }
 
         [Test]
@@ -65,7 +65,7 @@ if(@foo(""howdy""), {
 })
 ");
             var result = lambda();
-            Assert.AreEqual(57, result);
+            Assert.That(result, Is.EqualTo(57));
         }
 
         [Test]
@@ -80,7 +80,7 @@ if(foo, {
 })
 ");
             var result = lambda();
-            Assert.AreEqual(57, result);
+            Assert.That(result, Is.EqualTo(57));
         }
 
         [Test]
@@ -95,7 +95,7 @@ if(foo, {
 })
 ");
             var result = lambda();
-            Assert.AreEqual(67, result);
+            Assert.That(result, Is.EqualTo(67));
         }
 
         [Test]
@@ -110,7 +110,7 @@ if(eq(foo, 7), {
 })
 ");
             var result = lambda();
-            Assert.AreEqual(57, result);
+            Assert.That(result, Is.EqualTo(57));
         }
 
         [Test]
@@ -125,7 +125,7 @@ if(eq(foo, 7), {
 })
 ");
             var result = lambda();
-            Assert.AreEqual(67, result);
+            Assert.That(result, Is.EqualTo(67));
         }
 
         [Test]
@@ -140,7 +140,7 @@ if(not(eq(foo, 7)), {
 })
 ");
             var result = lambda();
-            Assert.AreEqual(67, result);
+            Assert.That(result, Is.EqualTo(67));
         }
 
         [Test]
@@ -155,7 +155,7 @@ if(not(eq(foo, 7)), {
 })
 ");
             var result = lambda();
-            Assert.AreEqual(57, result);
+            Assert.That(result, Is.EqualTo(57));
         }
 
         [Test]
@@ -170,7 +170,7 @@ if(mt(foo, 5), {
 })
 ");
             var result = lambda();
-            Assert.AreEqual(57, result);
+            Assert.That(result, Is.EqualTo(57));
         }
 
         [Test]
@@ -185,7 +185,7 @@ if(mt(foo, 7), {
 })
 ");
             var result = lambda();
-            Assert.AreEqual(67, result);
+            Assert.That(result, Is.EqualTo(67));
         }
 
         [Test]
@@ -200,7 +200,7 @@ if(lt(foo, 9), {
 })
 ");
             var result = lambda();
-            Assert.AreEqual(57, result);
+            Assert.That(result, Is.EqualTo(57));
         }
 
         [Test]
@@ -215,7 +215,7 @@ if(lt(foo, 3), {
 })
 ");
             var result = lambda();
-            Assert.AreEqual(67, result);
+            Assert.That(result, Is.EqualTo(67));
         }
 
         [Test]
@@ -230,7 +230,7 @@ if(mte(foo, 7), {
 })
 ");
             var result = lambda();
-            Assert.AreEqual(57, result);
+            Assert.That(result, Is.EqualTo(57));
         }
 
         [Test]
@@ -245,7 +245,7 @@ if(mte(foo, 7), {
 })
 ");
             var result = lambda();
-            Assert.AreEqual(67, result);
+            Assert.That(result, Is.EqualTo(67));
         }
 
         [Test]
@@ -260,7 +260,7 @@ if(lte(foo, 9), {
 })
 ");
             var result = lambda();
-            Assert.AreEqual(57, result);
+            Assert.That(result, Is.EqualTo(57));
         }
 
         [Test]
@@ -275,7 +275,7 @@ if(lte(foo, 3), {
 })
 ");
             var result = lambda();
-            Assert.AreEqual(67, result);
+            Assert.That(result, Is.EqualTo(67));
         }
 
         [Test]
@@ -292,7 +292,7 @@ if(any(@foo1, @foo2, @foo3), {
 })
 ");
             var result = lambda();
-            Assert.AreEqual(57, result);
+            Assert.That(result, Is.EqualTo(57));
         }
 
         [Test]
@@ -311,7 +311,7 @@ if(any(@foo1, @foo2(), @foo3), {
 })
 ");
             var result = lambda();
-            Assert.AreEqual(57, result);
+            Assert.That(result, Is.EqualTo(57));
         }
 
         [Test]
@@ -328,7 +328,7 @@ if(any(@foo1, @foo2, @foo3), {
 })
 ");
             var result = lambda();
-            Assert.AreEqual(67, result);
+            Assert.That(result, Is.EqualTo(67));
         }
 
         [Test]
@@ -342,7 +342,7 @@ if(any(), {
 })
 ");
             var result = lambda();
-            Assert.AreEqual(67, result);
+            Assert.That(result, Is.EqualTo(67));
         }
 
         [Test]
@@ -359,7 +359,7 @@ if(all(@foo1, @foo2, @foo3), {
 })
 ");
             var result = lambda();
-            Assert.AreEqual(57, result);
+            Assert.That(result, Is.EqualTo(57));
         }
 
         [Test]
@@ -376,7 +376,7 @@ if(all(@foo1, @foo2, @foo3), {
 })
 ");
             var result = lambda();
-            Assert.AreEqual(67, result);
+            Assert.That(result, Is.EqualTo(67));
         }
 
         [Test]
@@ -390,7 +390,7 @@ if(all(), {
 })
 ");
             var result = lambda();
-            Assert.AreEqual(57, result);
+            Assert.That(result, Is.EqualTo(57));
         }
     }
 }

--- a/lizzie.tests/Eval.cs
+++ b/lizzie.tests/Eval.cs
@@ -16,7 +16,7 @@ namespace lizzie.tests
         {
             var lambda = LambdaCompiler.Compile(@"eval(""+(57,10,10)"")");
             var result = lambda();
-            Assert.AreEqual(77, result);
+            Assert.That(result, Is.EqualTo(77));
         }
     }
 }

--- a/lizzie.tests/For.cs
+++ b/lizzie.tests/For.cs
@@ -24,7 +24,7 @@ namespace lizzie.tests
   i
 })");
             var result = lambda();
-            Assert.IsNull(result);
+            Assert.That(result, Is.Null);
         }
 
         [Test]
@@ -40,7 +40,7 @@ namespace lizzie.tests
   i
 })");
             var result = lambda();
-            Assert.AreEqual(2, result);
+            Assert.That(result, Is.EqualTo(2));
         }
     }
 }

--- a/lizzie.tests/Foreach.cs
+++ b/lizzie.tests/Foreach.cs
@@ -18,7 +18,7 @@ namespace lizzie.tests
   item
 })");
             var result = lambda();
-            Assert.IsNull(result);
+            Assert.That(result, Is.Null);
         }
 
         [Test]
@@ -28,7 +28,7 @@ namespace lizzie.tests
   item
 })");
             var result = lambda();
-            Assert.AreEqual(3, result);
+            Assert.That(result, Is.EqualTo(3));
         }
     }
 }

--- a/lizzie.tests/Functions.cs
+++ b/lizzie.tests/Functions.cs
@@ -22,7 +22,7 @@ var(@foo, function({
 }))
 foo()");
             var result = lambda();
-            Assert.AreEqual(57, result);
+            Assert.That(result, Is.EqualTo(57));
         }
 
         [Test]
@@ -34,7 +34,7 @@ var(@foo, function({
 }))
 foo()");
             var result = lambda();
-            Assert.AreEqual("Hello World", result);
+            Assert.That(result, Is.EqualTo("Hello World"));
         }
 
         [Test]
@@ -46,7 +46,7 @@ var(@foo, function({
 }, @input))
 foo(""Thomas"")");
             var result = lambda();
-            Assert.AreEqual("Hello Thomas", result);
+            Assert.That(result, Is.EqualTo("Hello Thomas"));
         }
 
         [Test]
@@ -58,7 +58,7 @@ var(@foo, function({
 }, @name, @old))
 foo(""Thomas"", 44)");
             var result = lambda();
-            Assert.AreEqual("Hello Thomas it seems you are 44 years old", result);
+            Assert.That(result, Is.EqualTo("Hello Thomas it seems you are 44 years old"));
         }
 
         [Test]
@@ -73,7 +73,7 @@ var(@foo, function({
 }))
 foo()");
             var result = lambda();
-            Assert.AreEqual(77, result);
+            Assert.That(result, Is.EqualTo(77));
         }
 
         [Test]
@@ -89,7 +89,7 @@ var(@foo, function({
 }))
 foo()");
             var result = lambda();
-            Assert.AreEqual(77, result);
+            Assert.That(result, Is.EqualTo(77));
         }
 
         [Test]
@@ -107,7 +107,7 @@ bar");
             } catch(LizzieRuntimeException) {
                 success = true;
             }
-            Assert.AreEqual(true, success);
+            Assert.That(success, Is.True);
         }
 
         [Test]
@@ -124,7 +124,7 @@ var(@func1, function({
 func1('success')
 ");
             var result = lambda();
-            Assert.AreEqual("success_yup", result);
+            Assert.That(result, Is.EqualTo("success_yup"));
         }
 
         [Test]
@@ -146,7 +146,7 @@ func2('success')
             } catch(LizzieRuntimeException) {
                 success = true;
             }
-            Assert.AreEqual(true, success);
+            Assert.That(success, Is.True);
         }
 
         [Test]
@@ -162,7 +162,7 @@ var(@func2, function({
 +(func1('foo'), func2('bar'))
 ");
             var result = lambda();
-            Assert.AreEqual("success1_foo_success2_bar", result);
+            Assert.That(result, Is.EqualTo("success1_foo_success2_bar"));
         }
 
         [Test]
@@ -170,7 +170,7 @@ var(@func2, function({
         {
             var lambda = LambdaCompiler.Compile("");
             var result = lambda();
-            Assert.IsNull(result);
+            Assert.That(result, Is.Null);
         }
 
         [Test]
@@ -182,7 +182,7 @@ var(@func, function({
 func()
 ");
             var result = lambda();
-            Assert.IsNull(result);
+            Assert.That(result, Is.Null);
         }
     }
 }

--- a/lizzie.tests/LambdaBuilder.cs
+++ b/lizzie.tests/LambdaBuilder.cs
@@ -18,7 +18,7 @@ namespace lizzie.tests
         {
             var lambda = LambdaCompiler.Compile("57");
             var result = lambda();
-            Assert.AreEqual(57, result);
+            Assert.That(result, Is.EqualTo(57));
         }
 
         [Test]
@@ -26,7 +26,7 @@ namespace lizzie.tests
         {
             var lambda = LambdaCompiler.Compile("%(/(+(5, *(5,-(20,15))),3),7)");
             var result = lambda();
-            Assert.AreEqual(3, result);
+            Assert.That(result, Is.EqualTo(3));
         }
 
         [Test]
@@ -38,7 +38,7 @@ var(@bar, +(foo, *(10,2)))
 bar";
             var lambda = LambdaCompiler.Compile(code);
             var result = lambda();
-            Assert.AreEqual(77, result);
+            Assert.That(result, Is.EqualTo(77));
         }
 
         [Test]
@@ -48,7 +48,7 @@ bar";
 var(@foo, var(@bar, 67))
 bar");
             var result = lambda();
-            Assert.AreEqual(67, result);
+            Assert.That(result, Is.EqualTo(67));
         }
 
         [Test]
@@ -58,7 +58,7 @@ bar");
 var(@foo, @var(@bar, 67))
 foo");
             var result = lambda();
-            Assert.IsTrue(result is Function<LambdaCompiler.Nothing>);
+            Assert.That(result is Function<LambdaCompiler.Nothing>, Is.True);
         }
 
         [Test]
@@ -73,7 +73,7 @@ bar");
             } catch (LizzieRuntimeException) {
                 success = true;
             }
-            Assert.IsTrue(success);
+            Assert.That(success, Is.True);
         }
 
         [Test]
@@ -84,7 +84,7 @@ var(@foo, @var(@bar, 57))
 foo()
 bar");
             var result = lambda();
-            Assert.AreEqual(57, result);
+            Assert.That(result, Is.EqualTo(57));
         }
 
         [Test]
@@ -111,15 +111,15 @@ var(@foo, +(55, bar, bar2))
 
             // Cloning a new binder and evaluating a new snippet of Lizzie code.
             var binder2 = masterBinder.Clone();
-            Assert.IsFalse(binder2.ContainsKey("bar2"));
+            Assert.That(binder2.ContainsKey("bar2"), Is.False);
             var lambda2 = LambdaCompiler.Compile<SimpleValues>(new SimpleValues(), (Binder<SimpleValues>)binder2, @"
 var(@foo, +(67, bar))
 ");
             var result2 = lambda2();
 
             // Sanity checking result.
-            Assert.AreEqual(67, result1);
-            Assert.AreEqual(77, result2);
+            Assert.That(result1, Is.EqualTo(67));
+            Assert.That(result2, Is.EqualTo(77));
         }
     }
 }

--- a/lizzie.tests/List.cs
+++ b/lizzie.tests/List.cs
@@ -18,12 +18,12 @@ namespace lizzie.tests
         {
             var lambda = LambdaCompiler.Compile("list(57, 67, 77)");
             var result = lambda();
-            Assert.IsTrue(result is List<object>);
+            Assert.That(result is List<object>, Is.True);
             var list = result as List<object>;
-            Assert.AreEqual(3, list.Count);
-            Assert.AreEqual(57, list[0]);
-            Assert.AreEqual(67, list[1]);
-            Assert.AreEqual(77, list[2]);
+            Assert.That(list.Count, Is.EqualTo(3));
+            Assert.That(list[0], Is.EqualTo(57));
+            Assert.That(list[1], Is.EqualTo(67));
+            Assert.That(list[2], Is.EqualTo(77));
         }
 
         [Test]
@@ -33,7 +33,7 @@ namespace lizzie.tests
 var(@foo, list(57, 67, 77))
 count(foo)");
             var result = lambda();
-            Assert.AreEqual(3, result);
+            Assert.That(result, Is.EqualTo(3));
         }
 
         [Test]
@@ -43,7 +43,7 @@ count(foo)");
 var(@foo, list(57, 67, 77))
 get(foo, 2)");
             var result = lambda();
-            Assert.AreEqual(77, result);
+            Assert.That(result, Is.EqualTo(77));
         }
 
         [Test]
@@ -54,12 +54,12 @@ var(@foo, list(57))
 add(foo, 67, 77)
 foo");
             var result = lambda();
-            Assert.IsTrue(result is List<object>);
+            Assert.That(result is List<object>, Is.True);
             var list = result as List<object>;
-            Assert.AreEqual(3, list.Count);
-            Assert.AreEqual(57, list[0]);
-            Assert.AreEqual(67, list[1]);
-            Assert.AreEqual(77, list[2]);
+            Assert.That(list.Count, Is.EqualTo(3));
+            Assert.That(list[0], Is.EqualTo(57));
+            Assert.That(list[1], Is.EqualTo(67));
+            Assert.That(list[2], Is.EqualTo(77));
         }
 
         [Test]
@@ -69,11 +69,11 @@ foo");
 var(@foo, list(57, 67, 77, 87))
 slice(foo, 1, 3)");
             var result = lambda();
-            Assert.IsTrue(result is List<object>);
+            Assert.That(result is List<object>, Is.True);
             var list = result as List<object>;
-            Assert.AreEqual(2, list.Count);
-            Assert.AreEqual(67, list[0]);
-            Assert.AreEqual(77, list[1]);
+            Assert.That(list.Count, Is.EqualTo(2));
+            Assert.That(list[0], Is.EqualTo(67));
+            Assert.That(list[1], Is.EqualTo(77));
         }
 
         [Test]
@@ -83,12 +83,12 @@ slice(foo, 1, 3)");
 var(@foo, list(57, 67, 77, 87))
 slice(foo, 1)");
             var result = lambda();
-            Assert.IsTrue(result is List<object>);
+            Assert.That(result is List<object>, Is.True);
             var list = result as List<object>;
-            Assert.AreEqual(3, list.Count);
-            Assert.AreEqual(67, list[0]);
-            Assert.AreEqual(77, list[1]);
-            Assert.AreEqual(87, list[2]);
+            Assert.That(list.Count, Is.EqualTo(3));
+            Assert.That(list[0], Is.EqualTo(67));
+            Assert.That(list[1], Is.EqualTo(77));
+            Assert.That(list[2], Is.EqualTo(87));
         }
 
         [Test]
@@ -98,13 +98,13 @@ slice(foo, 1)");
 var(@foo, list(57, 67, 77, 87))
 slice(foo)");
             var result = lambda();
-            Assert.IsTrue(result is List<object>);
+            Assert.That(result is List<object>, Is.True);
             var list = result as List<object>;
-            Assert.AreEqual(4, list.Count);
-            Assert.AreEqual(57, list[0]);
-            Assert.AreEqual(67, list[1]);
-            Assert.AreEqual(77, list[2]);
-            Assert.AreEqual(87, list[3]);
+            Assert.That(list.Count, Is.EqualTo(4));
+            Assert.That(list[0], Is.EqualTo(57));
+            Assert.That(list[1], Is.EqualTo(67));
+            Assert.That(list[2], Is.EqualTo(77));
+            Assert.That(list[3], Is.EqualTo(87));
         }
 
         [Test]
@@ -114,9 +114,9 @@ slice(foo)");
 var(@foo, list(57, 67, 77, 87))
 slice(foo, 1, 1)");
             var result = lambda();
-            Assert.IsTrue(result is List<object>);
+            Assert.That(result is List<object>, Is.True);
             var list = result as List<object>;
-            Assert.AreEqual(0, list.Count);
+            Assert.That(list.Count, Is.EqualTo(0));
         }
 
         [Test]
@@ -132,11 +132,11 @@ each(@ix, foo, {
 })
 bar");
             var result = lambda();
-            Assert.IsTrue(result is List<object>);
+            Assert.That(result is List<object>, Is.True);
             var list = result as List<object>;
-            Assert.AreEqual(2, list.Count);
-            Assert.AreEqual(57, list[0]);
-            Assert.AreEqual(77, list[1]);
+            Assert.That(list.Count, Is.EqualTo(2));
+            Assert.That(list[0], Is.EqualTo(57));
+            Assert.That(list[1], Is.EqualTo(77));
         }
 
         [Test]
@@ -152,11 +152,11 @@ each(@ix, foo, {
 })
 bar");
             var result = lambda();
-            Assert.IsTrue(result is List<object>);
+            Assert.That(result is List<object>, Is.True);
             var list = result as List<object>;
-            Assert.AreEqual(2, list.Count);
-            Assert.AreEqual("57", list[0]);
-            Assert.AreEqual("77", list[1]);
+            Assert.That(list.Count, Is.EqualTo(2));
+            Assert.That(list[0], Is.EqualTo("57"));
+            Assert.That(list[1], Is.EqualTo("77"));
         }
 
         [Test]
@@ -172,12 +172,12 @@ each(@ix, foo, {
 })
 bar");
             var result = lambda();
-            Assert.IsTrue(result is List<object>);
+            Assert.That(result is List<object>, Is.True);
             var list = result as List<object>;
-            Assert.AreEqual(3, list.Count);
-            Assert.AreEqual(57, list[0]);
-            Assert.AreEqual(77, list[1]);
-            Assert.AreEqual(88.88, list[2]);
+            Assert.That(list.Count, Is.EqualTo(3));
+            Assert.That(list[0], Is.EqualTo(57));
+            Assert.That(list[1], Is.EqualTo(77));
+            Assert.That(list[2], Is.EqualTo(88.88));
         }
 
         [Test]
@@ -190,12 +190,12 @@ var(@bar, each(@ix, foo, {
 }))
 bar");
             var result = lambda();
-            Assert.IsTrue(result is List<object>);
+            Assert.That(result is List<object>, Is.True);
             var list = result as List<object>;
-            Assert.AreEqual(3, list.Count);
-            Assert.AreEqual(67, list[0]);
-            Assert.AreEqual(77, list[1]);
-            Assert.AreEqual(87, list[2]);
+            Assert.That(list.Count, Is.EqualTo(3));
+            Assert.That(list[0], Is.EqualTo(67));
+            Assert.That(list[1], Is.EqualTo(77));
+            Assert.That(list[2], Is.EqualTo(87));
         }
 
         [Test]
@@ -205,7 +205,7 @@ bar");
 var(@foo, +(apply(list(57,10,10))))
 ");
             var result = lambda();
-            Assert.AreEqual(77, result);
+            Assert.That(result, Is.EqualTo(77));
         }
     }
 }

--- a/lizzie.tests/Map.cs
+++ b/lizzie.tests/Map.cs
@@ -18,7 +18,7 @@ namespace lizzie.tests
         {
             var lambda = LambdaCompiler.Compile("map()");
             var result = lambda();
-            Assert.IsTrue(result is Dictionary<string, object>);
+            Assert.That(result is Dictionary<string, object>, Is.True);
         }
 
         [Test]
@@ -32,9 +32,9 @@ map(
 ");
             var result = lambda();
             var map = result as Dictionary<string, object>;
-            Assert.AreEqual(2, map.Count);
-            Assert.AreEqual(57, map["foo"]);
-            Assert.AreEqual(77, map["bar"]);
+            Assert.That(map.Count, Is.EqualTo(2));
+            Assert.That(map["foo"], Is.EqualTo(57));
+            Assert.That(map["bar"], Is.EqualTo(77));
         }
 
         [Test]
@@ -47,7 +47,7 @@ count(map(
 ))
 ");
             var result = lambda();
-            Assert.AreEqual(2, result);
+            Assert.That(result, Is.EqualTo(2));
         }
 
         [Test]
@@ -61,7 +61,7 @@ var(@my-map, map(
 get(my-map, 'foo')
 ");
             var result = lambda();
-            Assert.AreEqual(57, result);
+            Assert.That(result, Is.EqualTo(57));
         }
 
         [Test]
@@ -76,10 +76,10 @@ my-map
 ");
             var result = lambda();
             var map = result as Dictionary<string, object>;
-            Assert.AreEqual(3, map.Count);
-            Assert.AreEqual(57, map["foo"]);
-            Assert.AreEqual(77, map["bar"]);
-            Assert.AreEqual(99, map["howdy"]);
+            Assert.That(map.Count, Is.EqualTo(3));
+            Assert.That(map["foo"], Is.EqualTo(57));
+            Assert.That(map["bar"], Is.EqualTo(77));
+            Assert.That(map["howdy"], Is.EqualTo(99));
         }
 
         [Test]
@@ -95,16 +95,16 @@ my-map
 ");
             var result = lambda();
             var map = result as Dictionary<string, object>;
-            Assert.AreEqual(4, map.Count);
-            Assert.AreEqual(57, map["foo"]);
-            Assert.AreEqual(77, map["bar"]);
-            Assert.AreEqual(99, map["howdy"]);
-            Assert.IsTrue(map["world"] is List<object>);
+            Assert.That(map.Count, Is.EqualTo(4));
+            Assert.That(map["foo"], Is.EqualTo(57));
+            Assert.That(map["bar"], Is.EqualTo(77));
+            Assert.That(map["howdy"], Is.EqualTo(99));
+            Assert.That(map["world"] is List<object>, Is.True);
             var list = map["world"] as List<object>;
-            Assert.AreEqual(3, list.Count);
-            Assert.AreEqual(1, list[0]);
-            Assert.AreEqual(2, list[1]);
-            Assert.AreEqual(3, list[2]);
+            Assert.That(list.Count, Is.EqualTo(3));
+            Assert.That(list[0], Is.EqualTo(1));
+            Assert.That(list[1], Is.EqualTo(2));
+            Assert.That(list[2], Is.EqualTo(3));
         }
 
         [Test]
@@ -119,15 +119,15 @@ my-map
 ");
             var result = lambda();
             var map = result as Dictionary<string, object>;
-            Assert.AreEqual(1, map.Count);
+            Assert.That(map.Count, Is.EqualTo(1));
             var list = map["world"] as List<object>;
-            Assert.IsNotNull(list);
-            Assert.AreEqual(5, list.Count);
-            Assert.AreEqual(1, list[0]);
-            Assert.AreEqual(2, list[1]);
-            Assert.AreEqual(3, list[2]);
-            Assert.AreEqual(4, list[3]);
-            Assert.AreEqual(5, list[4]);
+            Assert.That(list, Is.Not.Null);
+            Assert.That(list.Count, Is.EqualTo(5));
+            Assert.That(list[0], Is.EqualTo(1));
+            Assert.That(list[1], Is.EqualTo(2));
+            Assert.That(list[2], Is.EqualTo(3));
+            Assert.That(list[3], Is.EqualTo(4));
+            Assert.That(list[4], Is.EqualTo(5));
         }
 
         [Test]
@@ -145,16 +145,16 @@ my-map
 ");
             var result = lambda();
             var map = result as Dictionary<string, object>;
-            Assert.AreEqual(1, map.Count);
+            Assert.That(map.Count, Is.EqualTo(1));
             var list = map["world"] as List<object>;
-            Assert.IsNotNull(list);
-            Assert.AreEqual(4, list.Count);
-            Assert.AreEqual(1, list[0]);
-            Assert.AreEqual(2, list[1]);
-            Assert.AreEqual(3, list[2]);
+            Assert.That(list, Is.Not.Null);
+            Assert.That(list.Count, Is.EqualTo(4));
+            Assert.That(list[0], Is.EqualTo(1));
+            Assert.That(list[1], Is.EqualTo(2));
+            Assert.That(list[2], Is.EqualTo(3));
             var innerMap = list[3] as Dictionary<string, object>;
-            Assert.IsNotNull(innerMap);
-            Assert.AreEqual("bar", innerMap["foo"]);
+            Assert.That(innerMap, Is.Not.Null);
+            Assert.That(innerMap["foo"], Is.EqualTo("bar"));
         }
 
         [Test]
@@ -172,7 +172,7 @@ each(@ix, my-map, {
 result
 ");
             var result = lambda();
-            Assert.AreEqual(57, result);
+            Assert.That(result, Is.EqualTo(57));
         }
     }
 }

--- a/lizzie.tests/Math.cs
+++ b/lizzie.tests/Math.cs
@@ -23,7 +23,7 @@ namespace lizzie.tests
             var binder = new Binder<LambdaCompiler.Nothing>();
             binder["+"] = Functions<LambdaCompiler.Nothing>.Add;
             var result = function(ctx, binder);
-            Assert.AreEqual(67, result);
+            Assert.That(result, Is.EqualTo(67));
         }
 
         [Test]
@@ -36,7 +36,7 @@ namespace lizzie.tests
             var binder = new Binder<LambdaCompiler.Nothing>();
             binder["+"] = Functions<LambdaCompiler.Nothing>.Add;
             var result = function(ctx, binder);
-            Assert.AreEqual(57, result);
+            Assert.That(result, Is.EqualTo(57));
         }
 
         [Test]
@@ -49,7 +49,7 @@ namespace lizzie.tests
             var binder = new Binder<LambdaCompiler.Nothing>();
             binder["+"] = Functions<LambdaCompiler.Nothing>.Add;
             var result = function(ctx, binder);
-            Assert.AreEqual(57, result);
+            Assert.That(result, Is.EqualTo(57));
         }
 
         [Test]
@@ -59,7 +59,7 @@ namespace lizzie.tests
 var(@foo,10)
 -(foo)");
             var result = lambda();
-            Assert.AreEqual(-10, result);
+            Assert.That(result, Is.EqualTo(-10));
         }
 
         [Test]
@@ -72,7 +72,7 @@ var(@foo,10)
             var binder = new Binder<LambdaCompiler.Nothing>();
             binder["+"] = Functions<LambdaCompiler.Nothing>.Add;
             var result = function(ctx, binder);
-            Assert.AreEqual(57.57, result);
+            Assert.That(result, Is.EqualTo(57.57));
         }
 
         [Test]
@@ -85,7 +85,7 @@ var(@foo,10)
             var binder = new Binder<LambdaCompiler.Nothing>();
             binder["+"] = Functions<LambdaCompiler.Nothing>.Add;
             var result = function(ctx, binder);
-            Assert.AreEqual("hello world", result);
+            Assert.That(result, Is.EqualTo("hello world"));
         }
 
         [Test]
@@ -98,7 +98,7 @@ var(@foo,10)
             var binder = new Binder<LambdaCompiler.Nothing>();
             binder["-"] = Functions<LambdaCompiler.Nothing>.Subtract;
             var result = function(ctx, binder);
-            Assert.AreEqual(57, result);
+            Assert.That(result, Is.EqualTo(57));
         }
 
         [Test]
@@ -111,7 +111,7 @@ var(@foo,10)
             var binder = new Binder<LambdaCompiler.Nothing>();
             binder["-"] = Functions<LambdaCompiler.Nothing>.Subtract;
             var result = function(ctx, binder);
-            Assert.AreEqual(57, result);
+            Assert.That(result, Is.EqualTo(57));
         }
 
         [Test]
@@ -124,7 +124,7 @@ var(@foo,10)
             var binder = new Binder<LambdaCompiler.Nothing>();
             binder["*"] = Functions<LambdaCompiler.Nothing>.Multiply;
             var result = function(ctx, binder);
-            Assert.AreEqual(35, result);
+            Assert.That(result, Is.EqualTo(35));
         }
 
         [Test]
@@ -137,7 +137,7 @@ var(@foo,10)
             var binder = new Binder<LambdaCompiler.Nothing>();
             binder["*"] = Functions<LambdaCompiler.Nothing>.Multiply;
             var result = function(ctx, binder);
-            Assert.AreEqual(70, result);
+            Assert.That(result, Is.EqualTo(70));
         }
 
         [Test]
@@ -150,7 +150,7 @@ var(@foo,10)
             var binder = new Binder<LambdaCompiler.Nothing>();
             binder["/"] = Functions<LambdaCompiler.Nothing>.Divide;
             var result = function(ctx, binder);
-            Assert.AreEqual(3.1, result);
+            Assert.That(result, Is.EqualTo(3.1));
         }
 
         [Test]
@@ -163,7 +163,7 @@ var(@foo,10)
             var binder = new Binder<LambdaCompiler.Nothing>();
             binder["/"] = Functions<LambdaCompiler.Nothing>.Divide;
             var result = function(ctx, binder);
-            Assert.AreEqual(10.01, result);
+            Assert.That(result, Is.EqualTo(10.01));
         }
 
         [Test]
@@ -176,7 +176,7 @@ var(@foo,10)
             var binder = new Binder<LambdaCompiler.Nothing>();
             binder["%"] = Functions<LambdaCompiler.Nothing>.Modulo;
             var result = function(ctx, binder);
-            Assert.AreEqual(2, result);
+            Assert.That(result, Is.EqualTo(2));
         }
 
         [Test]
@@ -189,7 +189,7 @@ var(@foo,10)
             var binder = new Binder<LambdaCompiler.Nothing>();
             binder["%"] = Functions<LambdaCompiler.Nothing>.Modulo;
             var result = function(ctx, binder);
-            Assert.AreEqual(1, result);
+            Assert.That(result, Is.EqualTo(1));
         }
     }
 }

--- a/lizzie.tests/Null.cs
+++ b/lizzie.tests/Null.cs
@@ -18,7 +18,7 @@ namespace lizzie.tests
         {
             var lambda = LambdaCompiler.Compile("null");
             var result = lambda();
-            Assert.IsNull(result);
+            Assert.That(result, Is.Null);
         }
 
         [Test]
@@ -30,7 +30,7 @@ if(eq(null, foo), {
   57
 })");
             var result = lambda();
-            Assert.AreEqual(57, result);
+            Assert.That(result, Is.EqualTo(57));
         }
 
         [Test]
@@ -42,7 +42,7 @@ if(not(eq(null, foo)), {
   57
 })");
             var result = lambda();
-            Assert.AreEqual(57, result);
+            Assert.That(result, Is.EqualTo(57));
         }
     }
 }

--- a/lizzie.tests/Parser.cs
+++ b/lizzie.tests/Parser.cs
@@ -21,7 +21,7 @@ namespace lizzie.tests
             var ctx = new LambdaCompiler.Nothing();
             var binder = new Binder<LambdaCompiler.Nothing>();
             var result = function(ctx, binder);
-            Assert.AreEqual(57, result);
+            Assert.That(result, Is.EqualTo(57));
         }
 
         [Test]
@@ -33,7 +33,7 @@ namespace lizzie.tests
             var ctx = new LambdaCompiler.Nothing();
             var binder = new Binder<LambdaCompiler.Nothing>();
             var result = function(ctx, binder);
-            Assert.AreEqual(57.67, result);
+            Assert.That(result, Is.EqualTo(57.67));
         }
 
         [Test]
@@ -45,7 +45,7 @@ namespace lizzie.tests
             var ctx = new LambdaCompiler.Nothing();
             var binder = new Binder<LambdaCompiler.Nothing>();
             var result = function(ctx, binder);
-            Assert.AreEqual(5767.0, result);
+            Assert.That(result, Is.EqualTo(5767.0));
         }
 
         [Test]
@@ -57,7 +57,7 @@ namespace lizzie.tests
             var ctx = new LambdaCompiler.Nothing();
             var binder = new Binder<LambdaCompiler.Nothing>();
             var result = function(ctx, binder);
-            Assert.AreEqual(57.67, result);
+            Assert.That(result, Is.EqualTo(57.67));
         }
 
         [Test]
@@ -69,7 +69,7 @@ namespace lizzie.tests
             var ctx = new LambdaCompiler.Nothing();
             var binder = new Binder<LambdaCompiler.Nothing>();
             var result = function(ctx, binder);
-            Assert.AreEqual("57", result);
+            Assert.That(result, Is.EqualTo("57"));
         }
 
         [Test]
@@ -82,7 +82,7 @@ namespace lizzie.tests
             var binder = new Binder<LambdaCompiler.Nothing>();
             binder["foo"] = "bar";
             var result = function(ctx, binder);
-            Assert.AreEqual("bar", result);
+            Assert.That(result, Is.EqualTo("bar"));
         }
 
         [Test]
@@ -95,7 +95,7 @@ namespace lizzie.tests
             var binder = new Binder<LambdaCompiler.Nothing>();
             binder["foo"] = 57;
             var result = function(ctx, binder);
-            Assert.AreEqual(57, result);
+            Assert.That(result, Is.EqualTo(57));
         }
 
         [Test]
@@ -110,7 +110,7 @@ namespace lizzie.tests
                 return 57;
             });
             var result = function(ctx, binder);
-            Assert.AreEqual(57, result);
+            Assert.That(result, Is.EqualTo(57));
         }
 
         [Test]
@@ -123,7 +123,7 @@ namespace lizzie.tests
             var binder = new Binder<LambdaCompiler.Nothing>();
             binder["foo"] = new LambdaCompiler.Nothing();
             var result = function(ctx, binder);
-            Assert.IsTrue(result is LambdaCompiler.Nothing);
+            Assert.That(result is LambdaCompiler.Nothing, Is.True);
         }
 
         [Test]
@@ -138,7 +138,7 @@ namespace lizzie.tests
                 return new LambdaCompiler.Nothing();
             });
             var result = function(ctx, binder);
-            Assert.IsTrue(result is LambdaCompiler.Nothing);
+            Assert.That(result is LambdaCompiler.Nothing, Is.True);
         }
 
         [Test]
@@ -151,7 +151,7 @@ namespace lizzie.tests
             var binder = new Binder<LambdaCompiler.Nothing>();
             binder["foo"] = 57;
             var result = function(ctx, binder);
-            Assert.AreEqual("foo", result);
+            Assert.That(result, Is.EqualTo("foo"));
         }
 
         [Test]
@@ -163,7 +163,7 @@ namespace lizzie.tests
             var ctx = new SimpleValues() { ValueInteger = 57 };
             var binder = new Binder<SimpleValues>();
             var result = function(ctx, binder);
-            Assert.AreEqual(57, result);
+            Assert.That(result, Is.EqualTo(57));
         }
 
         [Test]
@@ -175,7 +175,7 @@ namespace lizzie.tests
             var ctx = new SimpleValues();
             var binder = new Binder<SimpleValues>();
             var result = function(ctx, binder);
-            Assert.AreEqual(57, ctx.ValueInteger);
+            Assert.That(ctx.ValueInteger, Is.EqualTo(57));
         }
 
         [Test]
@@ -187,8 +187,8 @@ namespace lizzie.tests
             var ctx = new SimpleValues() { ValueInteger = 57 };
             var binder = new Binder<SimpleValues>();
             var result = function(ctx, binder);
-            Assert.IsNull(result);
-            Assert.AreEqual("57", ctx.ValueString);
+            Assert.That(result, Is.Null);
+            Assert.That(ctx.ValueString, Is.EqualTo("57"));
         }
 
         [Test]
@@ -202,8 +202,8 @@ set-value-integer(67)";
             var ctx = new SimpleValues();
             var binder = new Binder<SimpleValues>();
             var result = function(ctx, binder);
-            Assert.IsNull(result);
-            Assert.AreEqual(67, ctx.ValueInteger);
+            Assert.That(result, Is.Null);
+            Assert.That(ctx.ValueInteger, Is.EqualTo(67));
         }
 
         [Test]
@@ -217,8 +217,8 @@ add-integers(get-constant-integer(), get-value-integer())
             var ctx = new SimpleValues() { ValueInteger = 10 };
             var binder = new Binder<SimpleValues>();
             var result = function(ctx, binder);
-            Assert.IsNull(result);
-            Assert.AreEqual(67, ctx.ValueInteger);
+            Assert.That(result, Is.Null);
+            Assert.That(ctx.ValueInteger, Is.EqualTo(67));
         }
 
         [Test]
@@ -241,8 +241,8 @@ add-integers(
             var ctx = new SimpleValues();
             var binder = new Binder<SimpleValues>();
             var result = function(ctx, binder);
-            Assert.IsNull(result);
-            Assert.AreEqual(77, ctx.ValueInteger);
+            Assert.That(result, Is.Null);
+            Assert.That(ctx.ValueInteger, Is.EqualTo(77));
         }
 
         [Test]
@@ -254,7 +254,7 @@ add-integers(
             var ctx = new LambdaCompiler.Nothing();
             var binder = new Binder<LambdaCompiler.Nothing>();
             var result = function(ctx, binder);
-            Assert.IsTrue(result is Function<LambdaCompiler.Nothing>);
+            Assert.That(result is Function<LambdaCompiler.Nothing>, Is.True);
         }
     }
 }

--- a/lizzie.tests/String.cs
+++ b/lizzie.tests/String.cs
@@ -17,7 +17,7 @@ namespace lizzie.tests
         {
             var lambda = LambdaCompiler.Compile(@"substr(""foobarxyz"", 3)");
             var result = lambda();
-            Assert.AreEqual("barxyz", result);
+            Assert.That(result, Is.EqualTo("barxyz"));
         }
 
         [Test]
@@ -25,7 +25,7 @@ namespace lizzie.tests
         {
             var lambda = LambdaCompiler.Compile(@"substr(""foobarxyz"", 3, 3)");
             var result = lambda();
-            Assert.AreEqual("bar", result);
+            Assert.That(result, Is.EqualTo("bar"));
         }
 
         [Test]
@@ -33,7 +33,7 @@ namespace lizzie.tests
         {
             var lambda = LambdaCompiler.Compile(@"length(""foo"")");
             var result = lambda();
-            Assert.AreEqual(3, result);
+            Assert.That(result, Is.EqualTo(3));
         }
 
         [Test]
@@ -41,7 +41,7 @@ namespace lizzie.tests
         {
             var lambda = LambdaCompiler.Compile(@"replace(""foo"", ""o"", ""xx"")");
             var result = lambda();
-            Assert.AreEqual("fxxxx", result);
+            Assert.That(result, Is.EqualTo("fxxxx"));
         }
 
         [Test]
@@ -49,7 +49,7 @@ namespace lizzie.tests
         {
             var lambda = LambdaCompiler.Compile(@"replace('foo', 'o', 'xx')");
             var result = lambda();
-            Assert.AreEqual("fxxxx", result);
+            Assert.That(result, Is.EqualTo("fxxxx"));
         }
 
         [Test]
@@ -57,7 +57,7 @@ namespace lizzie.tests
         {
             var lambda = LambdaCompiler.Compile(@"'foo\'bar'");
             var result = lambda();
-            Assert.AreEqual("foo'bar", result);
+            Assert.That(result, Is.EqualTo("foo'bar"));
         }
 
         [Test]
@@ -65,7 +65,7 @@ namespace lizzie.tests
         {
             var lambda = LambdaCompiler.Compile(@"string(57)");
             var result = lambda();
-            Assert.AreEqual("57", result);
+            Assert.That(result, Is.EqualTo("57"));
         }
 
         [Test]
@@ -73,7 +73,7 @@ namespace lizzie.tests
         {
             var lambda = LambdaCompiler.Compile(@"number('57')");
             var result = lambda();
-            Assert.AreEqual(57, result);
+            Assert.That(result, Is.EqualTo(57));
         }
 
         [Test]
@@ -81,7 +81,7 @@ namespace lizzie.tests
         {
             var lambda = LambdaCompiler.Compile(@"string('57')");
             var result = lambda();
-            Assert.AreEqual("57", result);
+            Assert.That(result, Is.EqualTo("57"));
         }
 
         [Test]
@@ -89,7 +89,7 @@ namespace lizzie.tests
         {
             var lambda = LambdaCompiler.Compile(@"""foo\""bar""");
             var result = lambda();
-            Assert.AreEqual("foo\"bar", result);
+            Assert.That(result, Is.EqualTo("foo\"bar"));
         }
 
         [Test]
@@ -102,7 +102,7 @@ string(map(
 ))
 ");
             var result = lambda();
-            Assert.AreEqual(@"{""foo"":57,""bar"":67}", result);
+            Assert.That(result, Is.EqualTo(@"{""foo"":57,""bar"":67}"));
         }
 
         [Test]
@@ -115,7 +115,7 @@ string(map(
 ))
 ");
             var result = lambda();
-            Assert.AreEqual(@"{""foo"":""howdy"",""bar"":""world""}", result);
+            Assert.That(result, Is.EqualTo(@"{""foo"":""howdy"",""bar"":""world""}"));
         }
 
         [Test]
@@ -128,7 +128,7 @@ string(map(
 ))
 ");
             var result = lambda();
-            Assert.AreEqual(@"{""foo"":""howdy"",""bar"":""wor\""ld""}", result);
+            Assert.That(result, Is.EqualTo(@"{""foo"":""howdy"",""bar"":""wor\""ld""}"));
         }
 
         [Test]
@@ -141,7 +141,7 @@ string(list(
 ))
 ");
             var result = lambda();
-            Assert.AreEqual(@"[""foo"",""bar""]", result);
+            Assert.That(result, Is.EqualTo(@"[""foo"",""bar""]"));
         }
 
         [Test]
@@ -158,7 +158,7 @@ string(list(
 ))
 ");
             var result = lambda();
-            Assert.AreEqual(@"[""foo"",{""bar1"":57,""bar2"":77,""bar3"":[1,2,{""hello"":""world""}]}]", result);
+            Assert.That(result, Is.EqualTo(@"[""foo"",{""bar1"":57,""bar2"":77,""bar3"":[1,2,{""hello"":""world""}]}]"));
         }
 
         [Test]
@@ -169,8 +169,8 @@ json(""{'foo':57}"")
 ");
             var result = lambda();
             var map = result as Dictionary<string, object>;
-            Assert.IsNotNull(map);
-            Assert.AreEqual(57, map["foo"]);
+            Assert.That(map, Is.Not.Null);
+            Assert.That(map["foo"], Is.EqualTo(57));
         }
 
         [Test]
@@ -181,11 +181,11 @@ json(""[0,1,2]"")
 ");
             var result = lambda();
             var list = result as List<object>;
-            Assert.IsNotNull(list);
-            Assert.AreEqual(3, list.Count);
-            Assert.AreEqual(0, list[0]);
-            Assert.AreEqual(1, list[1]);
-            Assert.AreEqual(2, list[2]);
+            Assert.That(list, Is.Not.Null);
+            Assert.That(list.Count, Is.EqualTo(3));
+            Assert.That(list[0], Is.EqualTo(0));
+            Assert.That(list[1], Is.EqualTo(1));
+            Assert.That(list[2], Is.EqualTo(2));
         }
 
         [Test]
@@ -196,16 +196,16 @@ json(""[0,1,{'foo':57,'bar':77,'hello':'world'}]"")
 ");
             var result = lambda();
             var list = result as List<object>;
-            Assert.IsNotNull(list);
-            Assert.AreEqual(3, list.Count);
-            Assert.AreEqual(0, list[0]);
-            Assert.AreEqual(1, list[1]);
+            Assert.That(list, Is.Not.Null);
+            Assert.That(list.Count, Is.EqualTo(3));
+            Assert.That(list[0], Is.EqualTo(0));
+            Assert.That(list[1], Is.EqualTo(1));
             var map = list[2] as Dictionary<string, object>;
-            Assert.IsNotNull(map);
-            Assert.AreEqual(3, map.Count);
-            Assert.AreEqual(57, map["foo"]);
-            Assert.AreEqual(77, map["bar"]);
-            Assert.AreEqual("world", map["hello"]);
+            Assert.That(map, Is.Not.Null);
+            Assert.That(map.Count, Is.EqualTo(3));
+            Assert.That(map["foo"], Is.EqualTo(57));
+            Assert.That(map["bar"], Is.EqualTo(77));
+            Assert.That(map["hello"], Is.EqualTo("world"));
         }
 
         [Test]
@@ -217,7 +217,7 @@ json(""[0,1,{'foo':57,'bar':77,'hello':'world'}]"")
             } catch {
                 success = true;
             }
-            Assert.AreEqual(true, success);
+            Assert.That(success, Is.True);
         }
 
         [Test]
@@ -229,7 +229,7 @@ json(""[0,1,{'foo':57,'bar':77,'hello':'world'}]"")
             } catch {
                 success = true;
             }
-            Assert.AreEqual(true, success);
+            Assert.That(success, Is.True);
         }
 
         [Test]
@@ -241,7 +241,7 @@ json(""[0,1,{'foo':57,'bar':77,'hello':'world'}]"")
             } catch {
                 success = true;
             }
-            Assert.AreEqual(true, success);
+            Assert.That(success, Is.True);
         }
     }
 }

--- a/lizzie.tests/TokenizerTests.cs
+++ b/lizzie.tests/TokenizerTests.cs
@@ -19,7 +19,7 @@ namespace lizzie.tests
             var code = "a(1)";
             var tokenizer = new Tokenizer(new LizzieTokenizer());
             var list = new List<string>(tokenizer.Tokenize(code));
-            Assert.AreEqual(4, list.Count);
+            Assert.That(list.Count, Is.EqualTo(4));
         }
 
         [Test]
@@ -28,7 +28,7 @@ namespace lizzie.tests
             var code = @"a(""foo"")";
             var tokenizer = new Tokenizer(new LizzieTokenizer());
             var list = new List<string>(tokenizer.Tokenize(code));
-            Assert.AreEqual(6, list.Count);
+            Assert.That(list.Count, Is.EqualTo(6));
         }
 
         [Test]
@@ -37,7 +37,7 @@ namespace lizzie.tests
             var code = @"a(""foo"", 5, ""bar"")";
             var tokenizer = new Tokenizer(new LizzieTokenizer());
             var list = new List<string>(tokenizer.Tokenize(code));
-            Assert.AreEqual(12, list.Count);
+            Assert.That(list.Count, Is.EqualTo(12));
         }
 
         [Test]
@@ -46,7 +46,7 @@ namespace lizzie.tests
             var code = @"a(""foo"", bar(5), ""bar"")";
             var tokenizer = new Tokenizer(new LizzieTokenizer());
             var list = new List<string>(tokenizer.Tokenize(code));
-            Assert.AreEqual(15, list.Count);
+            Assert.That(list.Count, Is.EqualTo(15));
         }
 
         [Test]
@@ -55,7 +55,7 @@ namespace lizzie.tests
             var code = @"  a (   ""\""fo\""o""   ,bar(  5 )     ,""bar""   )   ";
             var tokenizer = new Tokenizer(new LizzieTokenizer());
             var list = new List<string>(tokenizer.Tokenize(code));
-            Assert.AreEqual(15, list.Count);
+            Assert.That(list.Count, Is.EqualTo(15));
         }
 
         [Test]
@@ -64,7 +64,7 @@ namespace lizzie.tests
             var code = @"a(""foo"", bar(5)) // , ""bar"")";
             var tokenizer = new Tokenizer(new LizzieTokenizer());
             var list = new List<string>(tokenizer.Tokenize(code));
-            Assert.AreEqual(11, list.Count);
+            Assert.That(list.Count, Is.EqualTo(11));
         }
 
         [Test]
@@ -79,7 +79,7 @@ a(""foo"" /* comment */,
 jo()";
             var tokenizer = new Tokenizer(new LizzieTokenizer());
             var list = new List<string>(tokenizer.Tokenize(code));
-            Assert.AreEqual(14, list.Count);
+            Assert.That(list.Count, Is.EqualTo(14));
         }
 
         [Test]
@@ -93,7 +93,7 @@ jo()";
             } catch (LizzieTokenizerException) {
                 success = true;
             }
-            Assert.AreEqual(true, success);
+            Assert.That(success, Is.True);
         }
 
         [Test]
@@ -102,7 +102,7 @@ jo()";
             var code = @"/**/";
             var tokenizer = new Tokenizer(new LizzieTokenizer());
             var list = new List<string>(tokenizer.Tokenize(code));
-            Assert.AreEqual(0, list.Count);
+            Assert.That(list.Count, Is.EqualTo(0));
         }
     }
 }

--- a/lizzie.tests/Try.cs
+++ b/lizzie.tests/Try.cs
@@ -29,9 +29,9 @@ var(@result, try({
 list(result, finallyFlag, catchFlag)
 ");
             var list = lambda() as List<object>;
-            Assert.AreEqual(57, list[0]);
-            Assert.AreEqual(1, list[1]);
-            Assert.IsNull(list[2]);
+            Assert.That(list[0], Is.EqualTo(57));
+            Assert.That(list[1], Is.EqualTo(1));
+            Assert.That(list[2], Is.Null);
         }
 
         [Test]
@@ -51,9 +51,9 @@ var(@result, try({
 list(result, finallyFlag, catchMsg)
 ");
             var list = lambda() as List<object>;
-            Assert.AreEqual(67, list[0]);
-            Assert.AreEqual(1, list[1]);
-            StringAssert.Contains("The 'add' keyword", list[2] as string);
+            Assert.That(list[0], Is.EqualTo(67));
+            Assert.That(list[1], Is.EqualTo(1));
+            Assert.That(list[2] as string, Does.Contain("The 'add' keyword"));
         }
     }
 }

--- a/lizzie.tests/Variables.cs
+++ b/lizzie.tests/Variables.cs
@@ -24,7 +24,7 @@ var(@foo, 57)";
             var binder = new Binder<LambdaCompiler.Nothing>();
             binder["var"] = Functions<LambdaCompiler.Nothing>.Var;
             var result = function(ctx, binder);
-            Assert.AreEqual(57, result);
+            Assert.That(result, Is.EqualTo(57));
         }
 
         [Test]
@@ -38,7 +38,7 @@ var(@foo, 57.67)";
             var binder = new Binder<LambdaCompiler.Nothing>();
             binder["var"] = Functions<LambdaCompiler.Nothing>.Var;
             var result = function(ctx, binder);
-            Assert.AreEqual(57.67, result);
+            Assert.That(result, Is.EqualTo(57.67));
         }
 
         [Test]
@@ -53,7 +53,7 @@ foo";
             var binder = new Binder<LambdaCompiler.Nothing>();
             binder["var"] = Functions<LambdaCompiler.Nothing>.Var;
             var result = function(ctx, binder);
-            Assert.AreEqual("bar", result);
+            Assert.That(result, Is.EqualTo("bar"));
         }
 
         [Test]
@@ -68,7 +68,7 @@ foo";
             var binder = new Binder<LambdaCompiler.Nothing>();
             binder["var"] = Functions<LambdaCompiler.Nothing>.Var;
             var result = function(ctx, binder);
-            Assert.AreEqual(57, result);
+            Assert.That(result, Is.EqualTo(57));
         }
 
         [Test]
@@ -85,7 +85,7 @@ foo";
             } catch (LizzieRuntimeException) {
                 success = true;
             }
-            Assert.IsTrue(success);
+            Assert.That(success, Is.True);
         }
 
         [Test]
@@ -105,7 +105,7 @@ var(@foo, 57)";
             } catch (LizzieRuntimeException) {
                 success = true;
             }
-            Assert.IsTrue(success);
+            Assert.That(success, Is.True);
         }
 
         [Test]
@@ -120,7 +120,7 @@ foo";
             var binder = new Binder<LambdaCompiler.Nothing>();
             binder["var"] = Functions<LambdaCompiler.Nothing>.Var;
             var result = function(ctx, binder);
-            Assert.IsNull(result);
+            Assert.That(result, Is.Null);
         }
 
         [Test]
@@ -137,7 +137,7 @@ foo";
             binder["var"] = Functions<LambdaCompiler.Nothing>.Var;
             binder["set"] = Functions<LambdaCompiler.Nothing>.Set;
             var result = function(ctx, binder);
-            Assert.AreEqual(67, result);
+            Assert.That(result, Is.EqualTo(67));
         }
 
         [Test]
@@ -154,7 +154,7 @@ foo";
             binder["var"] = Functions<LambdaCompiler.Nothing>.Var;
             binder["set"] = Functions<LambdaCompiler.Nothing>.Set;
             var result = function(ctx, binder);
-            Assert.IsNull(result);
+            Assert.That(result, Is.Null);
         }
 
         [Test]
@@ -174,7 +174,7 @@ var(@foo)";
             } catch(LizzieRuntimeException) {
                 success = true;
             }
-            Assert.AreEqual(true, success);
+            Assert.That(success, Is.True);
         }
 
         [Test]
@@ -191,7 +191,7 @@ foo";
             binder["var"] = Functions<LambdaCompiler.Nothing>.Var;
             binder["set"] = Functions<LambdaCompiler.Nothing>.Set;
             var result = function(ctx, binder);
-            Assert.AreEqual("bar", result);
+            Assert.That(result, Is.EqualTo("bar"));
         }
     }
 }

--- a/lizzie.tests/While.cs
+++ b/lizzie.tests/While.cs
@@ -20,7 +20,7 @@ namespace lizzie.tests
   57
 })");
             var result = lambda();
-            Assert.IsNull(result);
+            Assert.That(result, Is.Null);
         }
 
         [Test]
@@ -33,7 +33,7 @@ while({
   set(@i, +(i, 1))
 })");
             var result = lambda();
-            Assert.AreEqual(3, result);
+            Assert.That(result, Is.EqualTo(3));
         }
     }
 }


### PR DESCRIPTION
## Summary
- refactor test suite to use `Assert.That` with constraint-based syntax
- replace legacy `StringAssert.Contains` usage with `Does.Contain`

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b34f961900832ba4f55d82fea2e739