### PR TITLE
Add return and break keywords

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -498,6 +498,9 @@ foreach(@item, list(1,2,3), {
 })
 ```
 
+Any loop can be terminated prematurely with the `break` keyword. An optional
+argument to `break` becomes the value returned from the loop.
+
 ### The definition of truth in Lizzie
 
 Lizzie does not have any explicit _"true"_ or _"false"_ boolean types or values.
@@ -522,11 +525,12 @@ This is called _"implicit conversion to boolean"_, and everything in Lizzie,
 including the boolean value of _"false"_, will in fact evaluate to true.
 The only thing that evaluates to _"false"_ is null.
 
-### Wait, where's the return keyword?
+### Returning from a function
 
-Lizzie does not have a return keyword. This is because inside of a lambda object,
-whatever is evaluated last, before the lambda returns, will be implicitly returned
-as the _"value"_ of the lambda. Let's illustrate this with an example.
+In addition to implicitly returning the value of the last statement in a lambda,
+Lizzie also supports an explicit `return` keyword. Invoking `return` will stop
+execution of the current function and return the specified value, or `null` if
+no value is supplied. The following illustrates its use.
 
 ```javascript
 /*
@@ -539,9 +543,9 @@ var(@foo, function({
    * a value, otherwise we return 67
    */
   if(input, {
-    57
+    return(57)
   }, {
-    67
+    return(67)
   })
 
 }, @input))

--- a/lizzie.tests/Break.cs
+++ b/lizzie.tests/Break.cs
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2018 Thomas Hansen - thomas@gaiasoul.com
+ *
+ * Licensed under the terms of the MIT license, see the enclosed LICENSE
+ * file for details.
+ */
+
+using NUnit.Framework;
+using lizzie.exceptions;
+
+namespace lizzie.tests
+{
+    public class Break
+    {
+        [Test]
+        public void BreaksOutOfLoop()
+        {
+            var lambda = LambdaCompiler.Compile(@"var(@i,0)
+while({
+  lt(i,10)
+},{
+  if(eq(i,5), { break(i) })
+  set(@i, +(i,1))
+})");
+            var result = lambda();
+            Assert.AreEqual(5, result);
+        }
+
+        [Test]
+        public void BreakOutsideLoopThrows()
+        {
+            var lambda = LambdaCompiler.Compile("break()");
+            var success = false;
+            try {
+                lambda();
+            } catch (LizzieRuntimeException) {
+                success = true;
+            }
+            Assert.AreEqual(true, success);
+        }
+    }
+}

--- a/lizzie.tests/Return.cs
+++ b/lizzie.tests/Return.cs
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2018 Thomas Hansen - thomas@gaiasoul.com
+ *
+ * Licensed under the terms of the MIT license, see the enclosed LICENSE
+ * file for details.
+ */
+
+using NUnit.Framework;
+
+namespace lizzie.tests
+{
+    public class Return
+    {
+        [Test]
+        public void ReturnsValueAndSkipsRest()
+        {
+            var lambda = LambdaCompiler.Compile(@"var(@foo, function({
+  return(57)
+  99
+}))
+foo()");
+            var result = lambda();
+            Assert.AreEqual(57, result);
+        }
+
+        [Test]
+        public void ReturnFromRootStopsEvaluation()
+        {
+            var lambda = LambdaCompiler.Compile(@"return(57)
+99");
+            var result = lambda();
+            Assert.AreEqual(57, result);
+        }
+    }
+}

--- a/lizzie/Compiler.cs
+++ b/lizzie/Compiler.cs
@@ -104,12 +104,24 @@ namespace lizzie
             return new Lambda<TContext>((ctx, binder) => {
 
                 /*
-                 * Looping through each symbolic delegate, returning the 
+                 * Looping through each symbolic delegate, returning the
                  * return value from the last to caller.
                  */
                 object result = null;
-                foreach (var ix in functions) {
-                    result = ix(ctx, binder, null);
+                try
+                {
+                    foreach (var ix in functions)
+                    {
+                        result = ix(ctx, binder, null);
+                    }
+                }
+                catch (ReturnException re)
+                {
+                    return re.Value;
+                }
+                catch (BreakException)
+                {
+                    throw new LizzieRuntimeException("'break' invoked outside of a loop.");
                 }
                 return result;
             });

--- a/lizzie/LambdaCompiler.cs
+++ b/lizzie/LambdaCompiler.cs
@@ -105,11 +105,13 @@ namespace lizzie
             binder["lte"] = Functions<TContext>.Lte;
             binder["not"] = Functions<TContext>.Not;
 
-            // Loop functions.
+            // Flow control functions.
             binder["try"] = Functions<TContext>.Try;
             binder["while"] = Functions<TContext>.While;
             binder["for"] = Functions<TContext>.For;
             binder["foreach"] = Functions<TContext>.Foreach;
+            binder["return"] = Functions<TContext>.Return;
+            binder["break"] = Functions<TContext>.Break;
 
 
             // Boolean algebraic functions.

--- a/lizzie/exceptions/BreakException.cs
+++ b/lizzie/exceptions/BreakException.cs
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018 Thomas Hansen - thomas@gaiasoul.com
+ *
+ * Licensed under the terms of the MIT license, see the enclosed LICENSE
+ * file for details.
+ */
+
+using System;
+
+namespace lizzie.exceptions
+{
+    /// <summary>
+    /// Internal exception used to break out of loops.
+    /// </summary>
+    public class BreakException : Exception
+    {
+        /// <summary>
+        /// The value optionally associated with the break.
+        /// </summary>
+        public object Value { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BreakException"/> class.
+        /// </summary>
+        /// <param name="value">Optional value to return from the loop.</param>
+        public BreakException(object value)
+        {
+            Value = value;
+        }
+    }
+}

--- a/lizzie/exceptions/ReturnException.cs
+++ b/lizzie/exceptions/ReturnException.cs
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018 Thomas Hansen - thomas@gaiasoul.com
+ *
+ * Licensed under the terms of the MIT license, see the enclosed LICENSE
+ * file for details.
+ */
+
+using System;
+
+namespace lizzie.exceptions
+{
+    /// <summary>
+    /// Internal exception used to return from a function.
+    /// </summary>
+    public class ReturnException : Exception
+    {
+        /// <summary>
+        /// The value associated with the return statement.
+        /// </summary>
+        public object Value { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReturnException"/> class.
+        /// </summary>
+        /// <param name="value">Value to return from the function.</param>
+        public ReturnException(object value)
+        {
+            Value = value;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `return` and `break` keywords with control-flow exceptions
- allow loops to stop via `break` and functions to exit via `return`
- document new keywords and add unit tests

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b37dd4c544832bb3b4744cdd325401