### PR TITLE
Add Task and Thread concurrency primitives

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -851,6 +851,30 @@ back to caller. It will share the context object, but it will create a new stack
 not having access to the already dynamically declared variables. Notice that `eval`
 will load up the default keywords from the `LambdaCompiler` from you.
 
+### Concurrency
+
+Lizzie ships with primitive concurrency helpers exposed through the
+`task`, `await`, `thread` and `join` keywords.
+
+* `task` starts a new `Task` evaluating a lambda and returns the `Task` instance
+* `await` blocks until a `Task` completes and returns its result
+* `thread` starts a new `Thread` executing a lambda and returns the `Thread`
+* `join` blocks until a `Thread` has finished executing
+
+```javascript
+var(@t, task({
+  +(40, 2)
+}))
+await(t)   // => 42
+
+var(@res, 0)
+var(@th, thread({
+  set(@res, 5)
+}))
+join(th)
+res        // => 5
+```
+
 ### Lizzie types
 
 Lizzie is extremely weakly typed, and arguably only contains a handful of types.

--- a/lizzie.tests/Concurrency.cs
+++ b/lizzie.tests/Concurrency.cs
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2018 Thomas Hansen - thomas@gaiasoul.com
+ *
+ * Licensed under the terms of the MIT license, see the enclosed LICENSE
+ * file for details.
+ */
+
+using NUnit.Framework;
+
+namespace lizzie.tests
+{
+    public class Concurrency
+    {
+        [Test]
+        public void TaskReturnsValue()
+        {
+            var code = @"
+var(@t, task({
+  57
+}))
+await(t)
+";
+            var tokenizer = new Tokenizer(new LizzieTokenizer());
+            var function = Compiler.Compile<LambdaCompiler.Nothing>(tokenizer, code);
+            var ctx = new LambdaCompiler.Nothing();
+            var binder = new Binder<LambdaCompiler.Nothing>();
+            binder["var"] = Functions<LambdaCompiler.Nothing>.Var;
+            binder["task"] = Functions<LambdaCompiler.Nothing>.Task;
+            binder["await"] = Functions<LambdaCompiler.Nothing>.Await;
+            var result = function(ctx, binder);
+            Assert.That(result, Is.EqualTo(57));
+        }
+
+        [Test]
+        public void ThreadSetsValue()
+        {
+            var code = @"
+var(@result, 0)
+var(@th, thread({
+  set(@result, 57)
+}))
+join(th)
+result
+";
+            var tokenizer = new Tokenizer(new LizzieTokenizer());
+            var function = Compiler.Compile<LambdaCompiler.Nothing>(tokenizer, code);
+            var ctx = new LambdaCompiler.Nothing();
+            var binder = new Binder<LambdaCompiler.Nothing>();
+            binder["var"] = Functions<LambdaCompiler.Nothing>.Var;
+            binder["set"] = Functions<LambdaCompiler.Nothing>.Set;
+            binder["thread"] = Functions<LambdaCompiler.Nothing>.Thread;
+            binder["join"] = Functions<LambdaCompiler.Nothing>.Join;
+            var result = function(ctx, binder);
+            Assert.That(result, Is.EqualTo(57));
+        }
+    }
+}
+

--- a/lizzie/LambdaCompiler.cs
+++ b/lizzie/LambdaCompiler.cs
@@ -156,6 +156,12 @@ namespace lizzie
             // The eval function.
             binder["eval"] = Functions<TContext>.Eval;
 
+            // Concurrency functions.
+            binder["task"] = Functions<TContext>.Task;
+            binder["await"] = Functions<TContext>.Await;
+            binder["thread"] = Functions<TContext>.Thread;
+            binder["join"] = Functions<TContext>.Join;
+
             // Null is simply a constant yielding null.
             binder["null"] = null;
         }


### PR DESCRIPTION
## Summary
- add `task`, `await`, `thread` and `join` functions to support basic concurrency
- wire new functions into the default binder and document usage
- cover Task and Thread helpers with unit tests

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b383b87b94832b8eab7fc06f6ab614