### PR TITLE
Add capability-guarded standard modules

### DIFF
--- a/lizzie.tests/StdModules.cs
+++ b/lizzie.tests/StdModules.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using lizzie.Runtime;
+using lizzie.Std;
+
+namespace lizzie.tests
+{
+    public class StdModules
+    {
+        private class TestLimiter : IResourceLimiter
+        {
+            public Capability? Requested { get; private set; }
+            public void Demand(Capability capability)
+            {
+                Requested = capability;
+            }
+        }
+
+        [Test]
+        public void TimeNowRequiresCapability()
+        {
+            var limiter = new TestLimiter();
+            var result = Time.now(limiter);
+            Assert.That(limiter.Requested, Is.EqualTo(Capability.Time));
+            Assert.That(result, Is.GreaterThan(0));
+        }
+
+        [Test]
+        public async Task AsyncNextTickRunsCallback()
+        {
+            var limiter = new TestLimiter();
+            bool called = false;
+            await Async.nextTick(() => called = true, limiter);
+            Assert.True(called);
+            Assert.That(limiter.Requested, Is.EqualTo(Capability.Async));
+        }
+
+        [Test]
+        public void RandNextIntProducesValue()
+        {
+            var limiter = new TestLimiter();
+            Rand.seed(42, limiter);
+            var value = Rand.nextInt(0, 10, limiter);
+            Assert.That(limiter.Requested, Is.EqualTo(Capability.Random));
+            Assert.That(value, Is.InRange(0, 9));
+        }
+    }
+}

--- a/lizzie/Runtime/Capability.cs
+++ b/lizzie/Runtime/Capability.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace lizzie.Runtime
+{
+    [Flags]
+    public enum Capability
+    {
+        None = 0,
+        Time = 1 << 0,
+        Async = 1 << 1,
+        Random = 1 << 2
+    }
+}

--- a/lizzie/Runtime/IResourceLimiter.cs
+++ b/lizzie/Runtime/IResourceLimiter.cs
@@ -2,5 +2,12 @@ namespace lizzie.Runtime
 {
     public interface IResourceLimiter
     {
+        /// <summary>
+        /// Ensures the caller has been granted the specified capability.
+        /// Implementations should throw if the capability is not available
+        /// or resources have been exhausted.
+        /// </summary>
+        /// <param name="capability">The capability required by the caller.</param>
+        void Demand(Capability capability);
     }
 }

--- a/lizzie/Std/Async.cs
+++ b/lizzie/Std/Async.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading.Tasks;
+using lizzie.Runtime;
+
+namespace lizzie.Std
+{
+    public static class Async
+    {
+        /// <summary>
+        /// Queues the provided callback to execute asynchronously on the thread pool.
+        /// </summary>
+        public static Task nextTick(Action fn, IResourceLimiter limiter)
+        {
+            limiter.Demand(Capability.Async);
+            return Task.Run(fn);
+        }
+    }
+}

--- a/lizzie/Std/Rand.cs
+++ b/lizzie/Std/Rand.cs
@@ -1,0 +1,37 @@
+using System;
+using lizzie.Runtime;
+
+namespace lizzie.Std
+{
+    public static class Rand
+    {
+        private static Random _rng = new();
+
+        /// <summary>
+        /// Seeds the internal pseudo random number generator.
+        /// </summary>
+        public static void seed(int n, IResourceLimiter limiter)
+        {
+            limiter.Demand(Capability.Random);
+            _rng = new Random(n);
+        }
+
+        /// <summary>
+        /// Returns a floating point value in the range [0,1).
+        /// </summary>
+        public static double nextFloat(IResourceLimiter limiter)
+        {
+            limiter.Demand(Capability.Random);
+            return _rng.NextDouble();
+        }
+
+        /// <summary>
+        /// Returns an integer between the supplied bounds.
+        /// </summary>
+        public static int nextInt(int min, int max, IResourceLimiter limiter)
+        {
+            limiter.Demand(Capability.Random);
+            return _rng.Next(min, max);
+        }
+    }
+}

--- a/lizzie/Std/Time.cs
+++ b/lizzie/Std/Time.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading.Tasks;
+using lizzie.Runtime;
+
+namespace lizzie.Std
+{
+    public static class Time
+    {
+        /// <summary>
+        /// Returns the current time in milliseconds since the Unix epoch.
+        /// </summary>
+        public static double now(IResourceLimiter limiter)
+        {
+            limiter.Demand(Capability.Time);
+            return DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        }
+
+        /// <summary>
+        /// Asynchronously sleeps for the specified number of milliseconds.
+        /// </summary>
+        public static Task sleep(int ms, IResourceLimiter limiter)
+        {
+            limiter.Demand(Capability.Time);
+            return Task.Delay(ms);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce runtime capability enumeration and limiter demand API
- add std/time, std/async and std/rand modules guarded by capabilities
- cover new modules with basic unit tests

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b864e633f4832babe3f003c5f80f2f