### PR TITLE
Implement runtime infrastructure and support services

### DIFF
--- a/lizzie.tests/StdModules.cs
+++ b/lizzie.tests/StdModules.cs
@@ -11,10 +11,10 @@ namespace lizzie.tests
         private class TestLimiter : IResourceLimiter
         {
             public Capability? Requested { get; private set; }
-            public void Demand(Capability capability)
-            {
-                Requested = capability;
-            }
+            public void Enter() { }
+            public void Exit() { }
+            public void Tick() { }
+            public void Demand(Capability capability) => Requested = capability;
         }
 
         [Test]
@@ -32,7 +32,7 @@ namespace lizzie.tests
             var limiter = new TestLimiter();
             bool called = false;
             await Async.nextTick(() => called = true, limiter);
-            Assert.True(called);
+            Assert.That(called, Is.True);
             Assert.That(limiter.Requested, Is.EqualTo(Capability.Async));
         }
 

--- a/lizzie.tests/lizzie.tests.csproj
+++ b/lizzie.tests/lizzie.tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="context_types\" />

--- a/lizzie/Runtime/CapabilitySandbox.cs
+++ b/lizzie/Runtime/CapabilitySandbox.cs
@@ -1,0 +1,27 @@
+namespace lizzie.Runtime
+{
+    /// <summary>
+    /// Sandbox policy based on a set of capabilities.
+    /// </summary>
+    public class CapabilitySandbox : ISandboxPolicy
+    {
+        private Capability _capabilities;
+
+        public CapabilitySandbox(Capability initial = Capability.None)
+        {
+            _capabilities = initial;
+        }
+
+        public bool Has(Capability capability) => (_capabilities & capability) == capability;
+
+        public void Allow(Capability capability)
+        {
+            _capabilities |= capability;
+        }
+
+        public void Deny(Capability capability)
+        {
+            _capabilities &= ~capability;
+        }
+    }
+}

--- a/lizzie/Runtime/CompositeModuleLoader.cs
+++ b/lizzie/Runtime/CompositeModuleLoader.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.IO;
+
+namespace lizzie.Runtime
+{
+    /// <summary>
+    /// Module loader that checks embedded modules before falling back to disk.
+    /// </summary>
+    public class CompositeModuleLoader : IModuleLoader
+    {
+        private readonly IDictionary<string, string> _embedded;
+        private readonly string _basePath;
+
+        public CompositeModuleLoader(IDictionary<string, string>? embedded = null, string? basePath = null)
+        {
+            _embedded = embedded ?? new Dictionary<string, string>();
+            _basePath = basePath ?? Directory.GetCurrentDirectory();
+        }
+
+        public bool TryLoad(string name, out string code)
+        {
+            if (_embedded.TryGetValue(name, out code))
+            {
+                return true;
+            }
+
+            var path = Path.Combine(_basePath, name);
+            if (File.Exists(path))
+            {
+                code = File.ReadAllText(path);
+                return true;
+            }
+
+            code = string.Empty;
+            return false;
+        }
+    }
+}

--- a/lizzie/Runtime/DefaultHostServices.cs
+++ b/lizzie/Runtime/DefaultHostServices.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace lizzie.Runtime
+{
+    /// <summary>
+    /// Default implementation of host services providing a deterministic RNG and clock.
+    /// </summary>
+    public class DefaultHostServices : IHostServices
+    {
+        private class SystemClock : IClock
+        {
+            public DateTime UtcNow => DateTime.UtcNow;
+        }
+
+        public Random Random { get; }
+        public IClock Clock { get; }
+
+        public DefaultHostServices(int? seed = null, IClock? clock = null)
+        {
+            Random = seed.HasValue ? new Random(seed.Value) : new Random();
+            Clock = clock ?? new SystemClock();
+        }
+    }
+}

--- a/lizzie/Runtime/DefaultResourceLimiter.cs
+++ b/lizzie/Runtime/DefaultResourceLimiter.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Diagnostics;
+
+namespace lizzie.Runtime
+{
+    /// <summary>
+    /// Resource limiter enforcing instruction count, timeout and call depth.
+    /// </summary>
+    public class DefaultResourceLimiter : IResourceLimiter
+    {
+        private readonly int _maxInstructions;
+        private readonly TimeSpan? _timeout;
+        private readonly int _maxDepth;
+        private readonly Stopwatch _stopwatch = new();
+        private int _instructions;
+        private int _depth;
+
+        public DefaultResourceLimiter(int maxInstructions = 0, TimeSpan? timeout = null, int maxDepth = int.MaxValue)
+        {
+            _maxInstructions = maxInstructions;
+            _timeout = timeout;
+            _maxDepth = maxDepth;
+            if (timeout.HasValue)
+                _stopwatch.Start();
+        }
+
+        public void Enter()
+        {
+            _depth++;
+            if (_depth > _maxDepth)
+                throw new InvalidOperationException("Maximum call depth exceeded");
+        }
+
+        public void Exit()
+        {
+            if (_depth > 0)
+                _depth--;
+        }
+
+        public void Tick()
+        {
+            _instructions++;
+            if (_maxInstructions > 0 && _instructions > _maxInstructions)
+                throw new InvalidOperationException("Instruction limit exceeded");
+            if (_timeout.HasValue && _stopwatch.Elapsed > _timeout.Value)
+                throw new TimeoutException("Execution timed out");
+        }
+
+        public void Demand(Capability capability)
+        {
+            // This limiter does not track capabilities; method provided for interface compatibility.
+        }
+    }
+}

--- a/lizzie/Runtime/DefaultRuntime.cs
+++ b/lizzie/Runtime/DefaultRuntime.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading.Tasks;
 using lizzie.Runtime.Config;
 using lizzie.exceptions;
@@ -35,7 +37,8 @@ namespace lizzie.Runtime
                 entries.Add(new SourceMapEntry(moduleName, i + 1, 1, lines[i]));
             }
             var module = new CompiledModule(moduleName, new SourceMap(entries));
-            _cache.Store(module);
+            var hash = ComputeHash(code);
+            _cache.Store(hash, moduleName, module);
             return module;
         }
 
@@ -66,6 +69,12 @@ namespace lizzie.Runtime
                 await Task.Yield();
             }
             return ScriptValue.Null;
+        }
+        private static string ComputeHash(string code)
+        {
+            using var sha = SHA256.Create();
+            var bytes = sha.ComputeHash(Encoding.UTF8.GetBytes(code));
+            return Convert.ToHexString(bytes);
         }
     }
 }

--- a/lizzie/Runtime/DefaultScheduler.cs
+++ b/lizzie/Runtime/DefaultScheduler.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace lizzie.Runtime
+{
+    /// <summary>
+    /// Simple scheduler implementing a micro task queue and delay feature.
+    /// </summary>
+    public class DefaultScheduler : IScheduler
+    {
+        private readonly Queue<Func<Task>> _microTasks = new();
+
+        public void QueueMicrotask(Func<Task> task)
+        {
+            if (task == null) throw new ArgumentNullException(nameof(task));
+            lock (_microTasks)
+            {
+                _microTasks.Enqueue(task);
+            }
+        }
+
+        public Task Delay(TimeSpan delay)
+        {
+            return Task.Delay(delay);
+        }
+
+        public async Task DrainAsync()
+        {
+            while (true)
+            {
+                Func<Task>? next = null;
+                lock (_microTasks)
+                {
+                    if (_microTasks.Count > 0)
+                        next = _microTasks.Dequeue();
+                }
+
+                if (next == null)
+                    break;
+
+                await next();
+            }
+        }
+    }
+}

--- a/lizzie/Runtime/DefaultScriptContext.cs
+++ b/lizzie/Runtime/DefaultScriptContext.cs
@@ -1,0 +1,28 @@
+namespace lizzie.Runtime
+{
+    /// <summary>
+    /// Default implementation of <see cref="IScriptContext"/> assembling the various runtime services.
+    /// </summary>
+    public class DefaultScriptContext : IScriptContext
+    {
+        public IScheduler Scheduler { get; }
+        public ISandboxPolicy Sandbox { get; }
+        public IBindingRegistry Bindings { get; }
+        public IResourceLimiter Resources { get; }
+        public IHostServices Host { get; }
+
+        public DefaultScriptContext(
+            IScheduler? scheduler = null,
+            ISandboxPolicy? sandbox = null,
+            IBindingRegistry? bindings = null,
+            IResourceLimiter? resources = null,
+            IHostServices? host = null)
+        {
+            Scheduler = scheduler ?? new DefaultScheduler();
+            Sandbox = sandbox ?? new NoopSandboxPolicy();
+            Bindings = bindings ?? new SimpleBindingRegistry();
+            Resources = resources ?? new DefaultResourceLimiter();
+            Host = host ?? new DefaultHostServices();
+        }
+    }
+}

--- a/lizzie/Runtime/IBindingRegistry.cs
+++ b/lizzie/Runtime/IBindingRegistry.cs
@@ -1,6 +1,18 @@
 namespace lizzie.Runtime
 {
+    /// <summary>
+    /// Registry responsible for storing script bindings.
+    /// </summary>
     public interface IBindingRegistry
     {
+        /// <summary>
+        /// Registers a binding with the specified name and value.
+        /// </summary>
+        void Bind(string name, object value);
+
+        /// <summary>
+        /// Attempts to resolve a binding by name.
+        /// </summary>
+        bool TryGet(string name, out object value);
     }
 }

--- a/lizzie/Runtime/IClock.cs
+++ b/lizzie/Runtime/IClock.cs
@@ -1,0 +1,13 @@
+namespace lizzie.Runtime
+{
+    /// <summary>
+    /// Abstraction over a clock to allow deterministic testing.
+    /// </summary>
+    public interface IClock
+    {
+        /// <summary>
+        /// Returns the current UTC time.
+        /// </summary>
+        System.DateTime UtcNow { get; }
+    }
+}

--- a/lizzie/Runtime/IHostServices.cs
+++ b/lizzie/Runtime/IHostServices.cs
@@ -1,6 +1,20 @@
+using System;
+
 namespace lizzie.Runtime
 {
+    /// <summary>
+    /// Provides access to host services such as randomness and clocks.
+    /// </summary>
     public interface IHostServices
     {
+        /// <summary>
+        /// Deterministic random number generator.
+        /// </summary>
+        Random Random { get; }
+
+        /// <summary>
+        /// Clock abstraction used for deterministic time.
+        /// </summary>
+        IClock Clock { get; }
     }
 }

--- a/lizzie/Runtime/IModuleLoader.cs
+++ b/lizzie/Runtime/IModuleLoader.cs
@@ -1,6 +1,16 @@
 namespace lizzie.Runtime
 {
+    /// <summary>
+    /// Responsible for loading script modules by name.
+    /// </summary>
     public interface IModuleLoader
     {
+        /// <summary>
+        /// Attempts to load the specified module.
+        /// </summary>
+        /// <param name="name">Name of the module.</param>
+        /// <param name="code">The loaded source code if successful.</param>
+        /// <returns><c>true</c> if the module was found; otherwise <c>false</c>.</returns>
+        bool TryLoad(string name, out string code);
     }
 }

--- a/lizzie/Runtime/IResourceLimiter.cs
+++ b/lizzie/Runtime/IResourceLimiter.cs
@@ -3,6 +3,22 @@ namespace lizzie.Runtime
     public interface IResourceLimiter
     {
         /// <summary>
+        /// Called when entering a new execution frame. Implementations can
+        /// use this to track recursion depth.
+        /// </summary>
+        void Enter();
+
+        /// <summary>
+        /// Called when leaving an execution frame.
+        /// </summary>
+        void Exit();
+
+        /// <summary>
+        /// Signals that a single instruction has executed.
+        /// </summary>
+        void Tick();
+
+        /// <summary>
         /// Ensures the caller has been granted the specified capability.
         /// Implementations should throw if the capability is not available
         /// or resources have been exhausted.

--- a/lizzie/Runtime/ISandboxPolicy.cs
+++ b/lizzie/Runtime/ISandboxPolicy.cs
@@ -1,6 +1,23 @@
 namespace lizzie.Runtime
 {
+    /// <summary>
+    /// Policy controlling which capabilities are available to a script.
+    /// </summary>
     public interface ISandboxPolicy
     {
+        /// <summary>
+        /// Checks if the specified capability has been granted.
+        /// </summary>
+        bool Has(Capability capability);
+
+        /// <summary>
+        /// Grants the specified capability.
+        /// </summary>
+        void Allow(Capability capability);
+
+        /// <summary>
+        /// Revokes the specified capability.
+        /// </summary>
+        void Deny(Capability capability);
     }
 }

--- a/lizzie/Runtime/IScheduler.cs
+++ b/lizzie/Runtime/IScheduler.cs
@@ -1,6 +1,28 @@
+using System;
+using System.Threading.Tasks;
+
 namespace lizzie.Runtime
 {
+    /// <summary>
+    /// Scheduler responsible for micro task execution and timing features.
+    /// </summary>
     public interface IScheduler
     {
+        /// <summary>
+        /// Queues a piece of work to be executed as a "micro task".
+        /// </summary>
+        /// <param name="task">The work to execute.</param>
+        void QueueMicrotask(Func<Task> task);
+
+        /// <summary>
+        /// Introduces an asynchronous delay.
+        /// </summary>
+        /// <param name="delay">Amount of time to delay.</param>
+        Task Delay(TimeSpan delay);
+
+        /// <summary>
+        /// Drains the micro task queue.
+        /// </summary>
+        Task DrainAsync();
     }
 }

--- a/lizzie/Runtime/IScriptContext.cs
+++ b/lizzie/Runtime/IScriptContext.cs
@@ -1,6 +1,14 @@
 namespace lizzie.Runtime
 {
+    /// <summary>
+    /// Represents the environment a script executes within.
+    /// </summary>
     public interface IScriptContext
     {
+        IScheduler Scheduler { get; }
+        ISandboxPolicy Sandbox { get; }
+        IBindingRegistry Bindings { get; }
+        IResourceLimiter Resources { get; }
+        IHostServices Host { get; }
     }
 }

--- a/lizzie/Runtime/InMemoryModuleCache.cs
+++ b/lizzie/Runtime/InMemoryModuleCache.cs
@@ -3,20 +3,28 @@ using System.Collections.Concurrent;
 namespace lizzie.Runtime
 {
     /// <summary>
-    /// Simple in-memory cache for compiled modules.
+    /// Simple in-memory cache for compiled modules keyed by hash and version.
     /// </summary>
     public class InMemoryModuleCache
     {
         private readonly ConcurrentDictionary<string, CompiledModule> _modules = new();
 
-        public void Store(CompiledModule module)
+        private static string BuildKey(string hash, string version) => $"{hash}:{version}";
+
+        /// <summary>
+        /// Stores the specified module using the supplied hash and version as key.
+        /// </summary>
+        public void Store(string hash, string version, CompiledModule module)
         {
-            _modules[module.Name] = module;
+            _modules[BuildKey(hash, version)] = module;
         }
 
-        public bool TryGet(string name, out CompiledModule module)
+        /// <summary>
+        /// Attempts to retrieve a module using the supplied hash and version.
+        /// </summary>
+        public bool TryGet(string hash, string version, out CompiledModule module)
         {
-            return _modules.TryGetValue(name, out module!);
+            return _modules.TryGetValue(BuildKey(hash, version), out module!);
         }
     }
 }

--- a/lizzie/Runtime/NoopSandboxPolicy.cs
+++ b/lizzie/Runtime/NoopSandboxPolicy.cs
@@ -1,0 +1,12 @@
+namespace lizzie.Runtime
+{
+    /// <summary>
+    /// Sandbox policy that permits all capabilities.
+    /// </summary>
+    public class NoopSandboxPolicy : ISandboxPolicy
+    {
+        public bool Has(Capability capability) => true;
+        public void Allow(Capability capability) { }
+        public void Deny(Capability capability) { }
+    }
+}

--- a/lizzie/Runtime/SimpleBindingRegistry.cs
+++ b/lizzie/Runtime/SimpleBindingRegistry.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace lizzie.Runtime
+{
+    /// <summary>
+    /// Basic in-memory implementation of <see cref="IBindingRegistry"/>.
+    /// </summary>
+    public class SimpleBindingRegistry : IBindingRegistry
+    {
+        private readonly Dictionary<string, object> _bindings = new();
+
+        public void Bind(string name, object value)
+        {
+            _bindings[name] = value;
+        }
+
+        public bool TryGet(string name, out object value)
+        {
+            return _bindings.TryGetValue(name, out value!);
+        }
+    }
+}

--- a/lizzie/lizzie.csproj
+++ b/lizzie/lizzie.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PackageVersion>0.8.1</PackageVersion>
     <Authors>Thomas Hansen</Authors>
     <PackageLicenseUrl>https://github.com/polterguy/lizzie/blob/master/LICENSE</PackageLicenseUrl>
@@ -18,11 +18,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DocumentationFile>bin\Debug\net9.0\lizzie.xml</DocumentationFile>
+    <DocumentationFile>bin\Debug\net8.0\lizzie.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType></DebugType>
-    <DocumentationFile>bin\Release\nets9.0\lizzie.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\net8.0\lizzie.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="exceptions\" />


### PR DESCRIPTION
## Summary
- add default scheduler with microtask queue and delay support
- introduce sandbox policies and binding registry
- provide resource limiting, host services, and script context
- support module loading and caching with hash+version keys

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b8673c15f0832b8537ca473d7d5bcf