### PR TITLE
Add xUnit tests for runtime and security features

### DIFF
--- a/lizzie.tests/RuntimeFeaturesTests.cs
+++ b/lizzie.tests/RuntimeFeaturesTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using lizzie.Runtime;
+using lizzie.Runtime.Config;
+using lizzie.Std;
+using Xunit;
+
+namespace lizzie.tests
+{
+    public class RuntimeFeaturesTests
+    {
+        [Fact]
+        public void ExecutionTimeoutEnforced()
+        {
+            var limiter = new DefaultResourceLimiter(timeout: TimeSpan.FromMilliseconds(10));
+            Thread.Sleep(20);
+            Assert.Throws<TimeoutException>(() => limiter.Tick());
+        }
+
+        [Fact]
+        public void DeterministicRngWithSeed()
+        {
+            var limiter = new DefaultResourceLimiter();
+            Rand.seed(123, limiter);
+            var expected = new Random(123).Next(0, 100);
+            var actual = Rand.nextInt(0, 100, limiter);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ModuleLoadingAndCaching()
+        {
+            var runtime = new DefaultRuntime();
+            var code = "line1\nline2";
+            var module = runtime.Compile(code, "test");
+            using var sha = SHA256.Create();
+            var hash = Convert.ToHexString(sha.ComputeHash(Encoding.UTF8.GetBytes(code)));
+            var cacheField = typeof(DefaultRuntime).GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var cache = (InMemoryModuleCache)cacheField.GetValue(runtime)!;
+            Assert.True(cache.TryGet(hash, "test", out var cached));
+            Assert.Same(module, cached);
+        }
+
+        [Fact]
+        public void InstructionCountingByDefaultResourceLimiter()
+        {
+            var limiter = new DefaultResourceLimiter(maxInstructions: 3);
+            limiter.Tick();
+            limiter.Tick();
+            limiter.Tick();
+            Assert.Throws<InvalidOperationException>(() => limiter.Tick());
+        }
+
+        private class SandboxLimiter : IResourceLimiter
+        {
+            private readonly ISandboxPolicy _sandbox;
+            public SandboxLimiter(ISandboxPolicy sandbox) { _sandbox = sandbox; }
+            public void Enter() { }
+            public void Exit() { }
+            public void Tick() { }
+            public void Demand(Capability capability)
+            {
+                if (!_sandbox.Has(capability))
+                    throw new InvalidOperationException("Capability missing");
+            }
+        }
+
+        [Fact]
+        public void CapabilityChecksBlockUnauthorizedStdlibCalls()
+        {
+            var sandbox = new CapabilitySandbox();
+            var limiter = new SandboxLimiter(sandbox);
+            Assert.Throws<InvalidOperationException>(() => Time.now(limiter));
+        }
+    }
+}

--- a/lizzie.tests/lizzie.tests.csproj
+++ b/lizzie.tests/lizzie.tests.csproj
@@ -12,6 +12,11 @@
     <PackageReference Include="NUnit" Version="4.4.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <None Remove="packages.config" />


### PR DESCRIPTION
## Summary
- add xUnit-based tests covering timeout enforcement, deterministic RNG, module caching, instruction limits, and sandbox capability blocking
- include xUnit dependencies so both NUnit and xUnit tests run

## Testing
- `dotnet test lizzie.tests/lizzie.tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68b86b4bce6c832bbb9bbd00cf3d8acf