### PR TITLE
Add sample projects for Console REPL, Unity demo, and ASP.NET evaluation

### DIFF
--- a/samples/AspNetEval/AspNetEval.csproj
+++ b/samples/AspNetEval/AspNetEval.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../lizzie/lizzie.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/AspNetEval/Controllers/EvalController.cs
+++ b/samples/AspNetEval/Controllers/EvalController.cs
@@ -1,0 +1,26 @@
+using System;
+using Microsoft.AspNetCore.Mvc;
+using lizzie;
+using AspNetEval.Models;
+
+namespace AspNetEval.Controllers;
+
+[ApiController]
+[Route("eval")]
+public class EvalController : ControllerBase
+{
+    [HttpPost]
+    public IActionResult Post([FromBody] EvalRequest request)
+    {
+        try
+        {
+            var lambda = LambdaCompiler.Compile(request.Script);
+            var result = lambda();
+            return Ok(new { result });
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+}

--- a/samples/AspNetEval/Models/EvalRequest.cs
+++ b/samples/AspNetEval/Models/EvalRequest.cs
@@ -1,0 +1,6 @@
+namespace AspNetEval.Models;
+
+public class EvalRequest
+{
+    public string Script { get; set; } = string.Empty;
+}

--- a/samples/AspNetEval/Program.cs
+++ b/samples/AspNetEval/Program.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+
+var app = builder.Build();
+
+app.MapControllers();
+
+app.Run();

--- a/samples/ConsoleRepl/ConsoleRepl.csproj
+++ b/samples/ConsoleRepl/ConsoleRepl.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../lizzie/lizzie.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/ConsoleRepl/Program.cs
+++ b/samples/ConsoleRepl/Program.cs
@@ -1,0 +1,24 @@
+using System;
+using lizzie;
+
+Console.WriteLine("Lizzie REPL - type 'exit' to quit");
+string? line;
+while ((line = Console.ReadLine()) != null)
+{
+    if (string.Equals(line, "exit", StringComparison.OrdinalIgnoreCase))
+        break;
+
+    if (string.IsNullOrWhiteSpace(line))
+        continue;
+
+    try
+    {
+        var lambda = LambdaCompiler.Compile(line);
+        var result = lambda();
+        Console.WriteLine(result ?? "null");
+    }
+    catch (Exception ex)
+    {
+        Console.WriteLine($"Error: {ex.Message}");
+    }
+}

--- a/samples/UnityDemo/IUnityScheduler.cs
+++ b/samples/UnityDemo/IUnityScheduler.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace UnityDemo;
+
+public interface IUnityScheduler
+{
+    void PostToMainThread(Action action);
+}

--- a/samples/UnityDemo/MockUnityScheduler.cs
+++ b/samples/UnityDemo/MockUnityScheduler.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace UnityDemo;
+
+public class MockUnityScheduler : IUnityScheduler
+{
+    public void PostToMainThread(Action action)
+    {
+        Console.WriteLine("Running action on mock main thread...");
+        action();
+    }
+}

--- a/samples/UnityDemo/Program.cs
+++ b/samples/UnityDemo/Program.cs
@@ -1,0 +1,6 @@
+using UnityDemo;
+using lizzie;
+
+var context = new UnityContext(new MockUnityScheduler());
+var lambda = LambdaCompiler.Compile(context, "main-thread(function() { write('Hello from Unity demo') })");
+lambda();

--- a/samples/UnityDemo/UnityContext.cs
+++ b/samples/UnityDemo/UnityContext.cs
@@ -1,0 +1,29 @@
+using System;
+using lizzie;
+
+namespace UnityDemo;
+
+public class UnityContext
+{
+    readonly IUnityScheduler _scheduler;
+
+    public UnityContext(IUnityScheduler scheduler)
+    {
+        _scheduler = scheduler;
+    }
+
+    [Bind(Name = "write")]
+    public object Write(Binder<UnityContext> ctx, Arguments args)
+    {
+        Console.WriteLine(args.Get<string>(0));
+        return null;
+    }
+
+    [Bind(Name = "main-thread")]
+    public object MainThread(Binder<UnityContext> ctx, Arguments args)
+    {
+        var fn = (Function<UnityContext>)args.Get(0);
+        _scheduler.PostToMainThread(() => fn(this, ctx, new Arguments()));
+        return null;
+    }
+}

--- a/samples/UnityDemo/UnityDemo.csproj
+++ b/samples/UnityDemo/UnityDemo.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../lizzie/lizzie.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- Add `samples/ConsoleRepl` demonstrating line-by-line script evaluation
- Provide `samples/UnityDemo` with `IUnityScheduler.PostToMainThread` and a mock scheduler
- Introduce `samples/AspNetEval` exposing a POST `/eval` endpoint for script execution

## Testing
- `dotnet build samples/ConsoleRepl/ConsoleRepl.csproj`
- `dotnet build samples/UnityDemo/UnityDemo.csproj`
- `dotnet build samples/AspNetEval/AspNetEval.csproj`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b86cea8330832b81b8b2c4ebdb9c91