### PR TITLE
Organize and clarify documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,26 @@
 
 [![Build status](https://travis-ci.org/polterguy/lizzie.svg?master)](https://travis-ci.org/polterguy/lizzie)
 
+## Table of Contents
+
+- [Quick start](#quick-start)
+- [What is a Symbolic Delegate?](#what-is-a-symbolic-delegate)
+- [Binding Lizzie to your own types](#binding-lizzie-to-your-own-types)
+- [How small is Lizzie?](#how-small-is-lizzie)
+- [How fast is Lizzie](#how-fast-is-lizzie)
+  - [Execution speed](#execution-speed)
+- [A 5 minutes introductory video to Lizzie](#a-5-minutes-introductory-video-to-lizzie)
+- [Reference documentation](#reference-documentation)
+- [Installation](#installation)
+- [License](#license)
+
 Lizzie is a dynamic scripting language for .Net based upon a design pattern
 called _"Symbolic Delegates"_. This allows you to execute dynamically created
 scripts, that does neither compile nor are interpreted, but instead _"compiles"_
 directly down to managed CLR delegates. Below is an example of using Lizzie from
 C#.
+
+## Quick start
 
 ```csharp
 using System;
@@ -254,3 +269,8 @@ PM > Install-Package lizzie
 ```
 
 Or visit the [download page to get its source code](https://github.com/ProGraMajster/lizzie/releases)
+
+## License
+
+Licensed under the [MIT License](LICENSE).
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+# Lizzie Documentation
+
+This directory contains reference material for the Lizzie scripting language.
+
+- [Introduction and reference guide](introduction.md)
+
+Additional examples and usage information are available in the [project README](../README.md).
+

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,6 +1,35 @@
 
 # Lizzie reference guide
 
+## Table of Contents
+
+- [Binding your Lizzie code to your domain types](#binding-your-lizzie-code-to-your-domain-types)
+- [Pre-defined Lizzie functions](#pre-defined-lizzie-functions)
+  - [Declaring variables](#declaring-variables)
+  - [What's with the funny '@' symbol?](#whats-with-the-funny--symbol)
+  - [Changing a variable's value](#changing-a-variables-value)
+  - [Functions](#functions)
+  - [So what is a Symbolic Delegate anyway?](#so-what-is-a-symbolic-delegate-anyway)
+  - [Branching](#branching)
+  - [The definition of truth in Lizzie](#the-definition-of-truth-in-lizzie)
+  - [Returning from a function](#returning-from-a-function)
+  - [Testing for equality](#testing-for-equality)
+  - [OR and AND](#or-and-and)
+  - [Lazy condition evaluation](#lazy-condition-evaluation)
+  - [Lists](#lists)
+    - [Iterating lists](#iterating-lists)
+  - [Maps](#maps)
+  - [JSON conversion](#json-conversion)
+  - [Math](#math)
+  - [String manipulation](#string-manipulation)
+  - [Eval](#eval)
+  - [Concurrency](#concurrency)
+  - [Lizzie types](#lizzie-types)
+  - [Dependency Injection (IoC)](#dependency-injection-ioc)
+  - [Optimizing Lizzie](#optimizing-lizzie)
+    - [Caching your Lizzie lambda object](#caching-your-lizzie-lambda-object)
+  - [Donate](#donate)
+
 Lizzie is a programming language based upon the (good) ideas from Lisp, but
 without the _"funny syntax"_. Although this eliminates most of the
 peculiarities from Lisp, some _"weird"_ constructs are still necessary to create


### PR DESCRIPTION
## Summary
- add table of contents and license section to README
- index documentation with new docs/README
- include table of contents in reference guide for easier navigation

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b86f03764c832b955ecb34546c5539