### PR TITLE
Add FileSystem capability and update runtime defaults

### DIFF
--- a/lizzie.tests/RuntimeFeaturesTests.cs
+++ b/lizzie.tests/RuntimeFeaturesTests.cs
@@ -75,5 +75,19 @@ namespace lizzie.tests
             var limiter = new SandboxLimiter(sandbox);
             Assert.Throws<InvalidOperationException>(() => Time.now(limiter));
         }
+
+        [Fact]
+        public void ServerDefaultsAllowFileSystem()
+        {
+            var ctx = RuntimeProfiles.ServerDefaults();
+            Assert.True(ctx.Sandbox.Has(Capability.FileSystem));
+        }
+
+        [Fact]
+        public void UnityDefaultsDenyFileSystem()
+        {
+            var ctx = RuntimeProfiles.UnityDefaults();
+            Assert.False(ctx.Sandbox.Has(Capability.FileSystem));
+        }
     }
 }

--- a/lizzie/Runtime/Capability.cs
+++ b/lizzie/Runtime/Capability.cs
@@ -9,6 +9,7 @@ namespace lizzie.Runtime
         Time = 1 << 0,
         Async = 1 << 1,
         Random = 1 << 2,
-        UnityMainThread = 1 << 3
+        UnityMainThread = 1 << 3,
+        FileSystem = 1 << 4
     }
 }

--- a/lizzie/Runtime/RuntimeProfiles.cs
+++ b/lizzie/Runtime/RuntimeProfiles.cs
@@ -46,6 +46,7 @@ namespace lizzie.Runtime
             sandbox.Allow(Capability.Time);
             sandbox.Allow(Capability.Async);
             sandbox.Allow(Capability.Random);
+            sandbox.Allow(Capability.FileSystem);
             var limiter = new DefaultResourceLimiter();
             return new DefaultScriptContext(
                 scheduler: new DefaultScheduler(),


### PR DESCRIPTION
## Summary
- add `Capability.FileSystem` flag for sandboxed file access
- allow file system capability in server profile while keeping it disabled in Unity
- cover new capability defaults with tests

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b95880b39c832bb969ec87e1d88181