### PR TITLE
Add file system std module with capability and whitelist checks

### DIFF
--- a/lizzie.tests/StdFileTests.cs
+++ b/lizzie.tests/StdFileTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.IO;
+using lizzie.Runtime;
+using FileModule = lizzie.Std.File;
+using Xunit;
+
+namespace lizzie.tests
+{
+    public class StdFileTests
+    {
+        private class TestLimiter : IResourceLimiter
+        {
+            public Capability? Requested { get; private set; }
+            public void Enter() { }
+            public void Exit() { }
+            public void Tick() { }
+            public void Demand(Capability capability) => Requested = capability;
+        }
+
+        private class TestPolicy : IFilesystemPolicy
+        {
+            private readonly bool _allow;
+            public TestPolicy(bool allow) { _allow = allow; }
+            public bool IsPathAllowed(string path) => _allow;
+        }
+
+        [Fact]
+        public void ReadFileDemandsCapabilityAndRespectsPolicy()
+        {
+            var temp = Path.GetTempFileName();
+            System.IO.File.WriteAllText(temp, "hello");
+            var limiter = new TestLimiter();
+            var policy = new TestPolicy(true);
+            var content = FileModule.readFile(temp, limiter, policy);
+            Assert.Equal("hello", content);
+            Assert.Equal(Capability.FileSystem, limiter.Requested);
+        }
+
+        [Fact]
+        public void ReadFileDeniedWhenPolicyRejects()
+        {
+            var temp = Path.GetTempFileName();
+            System.IO.File.WriteAllText(temp, "hello");
+            var limiter = new TestLimiter();
+            var policy = new TestPolicy(false);
+            Assert.Throws<UnauthorizedAccessException>(() => FileModule.readFile(temp, limiter, policy));
+        }
+
+        [Fact]
+        public void BindingRegistryProvidesReadFile()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            var file = Path.Combine(dir, "a.txt");
+            System.IO.File.WriteAllText(file, "data");
+            var ctx = RuntimeProfiles.ServerDefaults(filesystemWhitelist: new[] { dir });
+            Assert.True(ctx.Bindings.TryGet("readFile", out var fn));
+            var reader = Assert.IsType<Func<string, string>>(fn);
+            var content = reader(file);
+            Assert.Equal("data", content);
+        }
+    }
+}

--- a/lizzie/Runtime/RuntimeProfiles.cs
+++ b/lizzie/Runtime/RuntimeProfiles.cs
@@ -23,12 +23,14 @@ namespace lizzie.Runtime
         {
             var sandbox = new CapabilitySandbox(Capability.UnityMainThread | Capability.Time | Capability.Async | Capability.Random);
             var limiter = new FrameBudgetLimiter(frameBudget);
-            return new DefaultScriptContext(
+            var ctx = new DefaultScriptContext(
                 scheduler: new DefaultScheduler(),
                 sandbox: sandbox,
                 bindings: new SimpleBindingRegistry(),
                 resources: limiter,
                 host: new DefaultHostServices());
+            ctx.BindFileModule();
+            return ctx;
         }
 
         /// <summary>
@@ -49,12 +51,14 @@ namespace lizzie.Runtime
             sandbox.Allow(Capability.Random);
             sandbox.Allow(Capability.FileSystem);
             var limiter = new DefaultResourceLimiter();
-            return new DefaultScriptContext(
+            var ctx = new DefaultScriptContext(
                 scheduler: new DefaultScheduler(),
                 sandbox: sandbox,
                 bindings: new SimpleBindingRegistry(),
                 resources: limiter,
                 host: new DefaultHostServices());
+            ctx.BindFileModule();
+            return ctx;
         }
 
         /// <summary>

--- a/lizzie/Runtime/StdBindingExtensions.cs
+++ b/lizzie/Runtime/StdBindingExtensions.cs
@@ -1,0 +1,26 @@
+using System;
+using FileModule = lizzie.Std.File;
+
+namespace lizzie.Runtime
+{
+    /// <summary>
+    /// Helpers for registering standard library functions in a binding registry.
+    /// </summary>
+    public static class StdBindingExtensions
+    {
+        /// <summary>
+        /// Registers file system functions in the provided script context's binding registry.
+        /// </summary>
+        public static void BindFileModule(this IScriptContext ctx)
+        {
+            if (ctx.Sandbox is not IFilesystemPolicy fs)
+                return;
+            var limiter = ctx.Resources;
+            ctx.Bindings.Bind("readFile", (Func<string, string>)(path => FileModule.readFile(path, limiter, fs)));
+            ctx.Bindings.Bind("writeFile", (Action<string, string>)((path, contents) => FileModule.writeFile(path, contents, limiter, fs)));
+            ctx.Bindings.Bind("listDir", (Func<string, string[]>)(path => FileModule.listDir(path, limiter, fs)));
+            ctx.Bindings.Bind("createDir", (Action<string>)(path => FileModule.createDir(path, limiter, fs)));
+            ctx.Bindings.Bind("delete", (Action<string>)(path => FileModule.delete(path, limiter, fs)));
+        }
+    }
+}

--- a/lizzie/Std/File.cs
+++ b/lizzie/Std/File.cs
@@ -1,0 +1,70 @@
+using System;
+using System.IO;
+using lizzie.Runtime;
+
+namespace lizzie.Std
+{
+    /// <summary>
+    /// File system operations exposed to scripts.
+    /// </summary>
+    public static class File
+    {
+        /// <summary>
+        /// Reads the contents of a file.
+        /// </summary>
+        public static string readFile(string path, IResourceLimiter limiter, IFilesystemPolicy policy)
+        {
+            limiter.Demand(Capability.FileSystem);
+            if (!policy.IsPathAllowed(path))
+                throw new UnauthorizedAccessException($"Path '{path}' is not allowed.");
+            return System.IO.File.ReadAllText(path);
+        }
+
+        /// <summary>
+        /// Writes text to a file, overwriting any existing content.
+        /// </summary>
+        public static void writeFile(string path, string contents, IResourceLimiter limiter, IFilesystemPolicy policy)
+        {
+            limiter.Demand(Capability.FileSystem);
+            if (!policy.IsPathAllowed(path))
+                throw new UnauthorizedAccessException($"Path '{path}' is not allowed.");
+            System.IO.File.WriteAllText(path, contents);
+        }
+
+        /// <summary>
+        /// Lists directory contents.
+        /// </summary>
+        public static string[] listDir(string path, IResourceLimiter limiter, IFilesystemPolicy policy)
+        {
+            limiter.Demand(Capability.FileSystem);
+            if (!policy.IsPathAllowed(path))
+                throw new UnauthorizedAccessException($"Path '{path}' is not allowed.");
+            return Directory.GetFileSystemEntries(path);
+        }
+
+        /// <summary>
+        /// Creates a directory at the specified path.
+        /// </summary>
+        public static void createDir(string path, IResourceLimiter limiter, IFilesystemPolicy policy)
+        {
+            limiter.Demand(Capability.FileSystem);
+            if (!policy.IsPathAllowed(path))
+                throw new UnauthorizedAccessException($"Path '{path}' is not allowed.");
+            Directory.CreateDirectory(path);
+        }
+
+        /// <summary>
+        /// Deletes a file or directory.
+        /// </summary>
+        public static void delete(string path, IResourceLimiter limiter, IFilesystemPolicy policy)
+        {
+            limiter.Demand(Capability.FileSystem);
+            if (!policy.IsPathAllowed(path))
+                throw new UnauthorizedAccessException($"Path '{path}' is not allowed.");
+            if (Directory.Exists(path))
+                Directory.Delete(path, true);
+            else if (System.IO.File.Exists(path))
+                System.IO.File.Delete(path);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add file operations stdlib module gated by capability and filesystem whitelist
- expose file functions via binding registry for script usage
- cover new module with tests and wire into runtime profiles

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b95b6d6a24832ba203bebe2704d402