### PR TITLE
Add tests for file system capability enforcement

### DIFF
--- a/lizzie.tests/FileSystemCapabilityTests.cs
+++ b/lizzie.tests/FileSystemCapabilityTests.cs
@@ -1,0 +1,90 @@
+using System;
+using System.IO;
+using lizzie.Runtime;
+using FileModule = lizzie.Std.File;
+using Xunit;
+
+namespace lizzie.tests
+{
+    public class FileSystemCapabilityTests
+    {
+        private class SandboxLimiter : IResourceLimiter
+        {
+            private readonly ISandboxPolicy _sandbox;
+            public SandboxLimiter(ISandboxPolicy sandbox) { _sandbox = sandbox; }
+            public void Enter() { }
+            public void Exit() { }
+            public void Tick() { }
+            public void Demand(Capability capability)
+            {
+                if (!_sandbox.Has(capability))
+                    throw new InvalidOperationException("Capability missing");
+            }
+        }
+
+        [Fact]
+        public void FileOperationsSucceedWhenCapabilityAllowedAndPathWhitelisted()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            var file = Path.Combine(dir, "a.txt");
+            System.IO.File.WriteAllText(file, "allowed");
+            try
+            {
+                var ctx = RuntimeProfiles.ServerDefaults(filesystemWhitelist: new[] { dir });
+                var limiter = new SandboxLimiter(ctx.Sandbox);
+                var policy = Assert.IsAssignableFrom<IFilesystemPolicy>(ctx.Sandbox);
+                var content = FileModule.readFile(file, limiter, policy);
+                Assert.Equal("allowed", content);
+            }
+            finally
+            {
+                Directory.Delete(dir, true);
+            }
+        }
+
+        [Fact]
+        public void FileOperationsDeniedWhenCapabilityMissing()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            var file = Path.Combine(dir, "a.txt");
+            System.IO.File.WriteAllText(file, "data");
+            try
+            {
+                var ctx = RuntimeProfiles.ServerDefaults(filesystemWhitelist: new[] { dir });
+                ctx.Sandbox.Deny(Capability.FileSystem);
+                var limiter = new SandboxLimiter(ctx.Sandbox);
+                var policy = Assert.IsAssignableFrom<IFilesystemPolicy>(ctx.Sandbox);
+                Assert.Throws<InvalidOperationException>(() => FileModule.readFile(file, limiter, policy));
+            }
+            finally
+            {
+                Directory.Delete(dir, true);
+            }
+        }
+
+        [Fact]
+        public void FileOperationsDeniedWhenPathOutsideWhitelist()
+        {
+            var allowedDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(allowedDir);
+            var disallowedDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(disallowedDir);
+            var file = Path.Combine(disallowedDir, "a.txt");
+            System.IO.File.WriteAllText(file, "nope");
+            try
+            {
+                var ctx = RuntimeProfiles.ServerDefaults(filesystemWhitelist: new[] { allowedDir });
+                var limiter = new SandboxLimiter(ctx.Sandbox);
+                var policy = Assert.IsAssignableFrom<IFilesystemPolicy>(ctx.Sandbox);
+                Assert.Throws<UnauthorizedAccessException>(() => FileModule.readFile(file, limiter, policy));
+            }
+            finally
+            {
+                Directory.Delete(allowedDir, true);
+                Directory.Delete(disallowedDir, true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add SandboxLimiter to test capability checks in file operations
- ensure readFile succeeds with allowed capability and whitelisted paths
- verify unauthorized access when capability is denied or paths are outside whitelist

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68b9ede8b8a4832ba4729e116d0f2fe7