### PR TITLE
Add network policy interface and enforce HTTP whitelists

### DIFF
--- a/lizzie.tests/RuntimeFeaturesTests.cs
+++ b/lizzie.tests/RuntimeFeaturesTests.cs
@@ -102,5 +102,14 @@ namespace lizzie.tests
             Assert.True(fsPolicy.IsPathAllowed(allowed));
             Assert.False(fsPolicy.IsPathAllowed(disallowed));
         }
+
+        [Fact]
+        public void HttpWhitelistEnforced()
+        {
+            var ctx = RuntimeProfiles.ServerDefaults(httpWhitelist: new[] { "https://example.com" });
+            var netPolicy = Assert.IsAssignableFrom<INetworkPolicy>(ctx.Sandbox);
+            Assert.True(netPolicy.IsOriginAllowed(new Uri("https://example.com/resource")));
+            Assert.False(netPolicy.IsOriginAllowed(new Uri("https://notallowed.com")));
+        }
     }
 }

--- a/lizzie/Runtime/INetworkPolicy.cs
+++ b/lizzie/Runtime/INetworkPolicy.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace lizzie.Runtime
+{
+    /// <summary>
+    /// Policy controlling which network origins are allowed for requests.
+    /// </summary>
+    public interface INetworkPolicy
+    {
+        /// <summary>
+        /// Determines whether the specified origin is permitted.
+        /// </summary>
+        bool IsOriginAllowed(Uri origin);
+    }
+}

--- a/lizzie/Runtime/RuntimeProfiles.cs
+++ b/lizzie/Runtime/RuntimeProfiles.cs
@@ -102,7 +102,7 @@ namespace lizzie.Runtime
         /// while delegating capability management to an internal
         /// <see cref="CapabilitySandbox"/>.
         /// </summary>
-        private sealed class ReadOnlySandboxPolicy : ISandboxPolicy, IFilesystemPolicy
+        private sealed class ReadOnlySandboxPolicy : ISandboxPolicy, IFilesystemPolicy, INetworkPolicy
         {
             private readonly CapabilitySandbox _capabilities = new();
 
@@ -130,6 +130,17 @@ namespace lizzie.Runtime
                         .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
                     if (full.StartsWith(allowedFull + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase)
                         || string.Equals(full, allowedFull, StringComparison.OrdinalIgnoreCase))
+                        return true;
+                }
+                return false;
+            }
+
+            public bool IsOriginAllowed(Uri origin)
+            {
+                var auth = origin.GetLeftPart(UriPartial.Authority);
+                foreach (var allowed in HttpWhitelist)
+                {
+                    if (string.Equals(auth, allowed, StringComparison.OrdinalIgnoreCase))
                         return true;
                 }
                 return false;


### PR DESCRIPTION
## Summary
- introduce INetworkPolicy for origin checks
- implement INetworkPolicy in RuntimeProfiles' ReadOnlySandboxPolicy
- test HTTP origin whitelisting in server defaults

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b9f1fef5d8832bbeecf436fc8db31a