### PR TITLE
Add network capability and conditional server whitelist

### DIFF
--- a/lizzie.tests/RuntimeFeaturesTests.cs
+++ b/lizzie.tests/RuntimeFeaturesTests.cs
@@ -107,9 +107,17 @@ namespace lizzie.tests
         public void HttpWhitelistEnforced()
         {
             var ctx = RuntimeProfiles.ServerDefaults(httpWhitelist: new[] { "https://example.com" });
+            Assert.True(ctx.Sandbox.Has(Capability.Network));
             var netPolicy = Assert.IsAssignableFrom<INetworkPolicy>(ctx.Sandbox);
             Assert.True(netPolicy.IsOriginAllowed(new Uri("https://example.com/resource")));
             Assert.False(netPolicy.IsOriginAllowed(new Uri("https://notallowed.com")));
+        }
+
+        [Fact]
+        public void NetworkCapabilityMissingWithoutWhitelist()
+        {
+            var ctx = RuntimeProfiles.ServerDefaults();
+            Assert.False(ctx.Sandbox.Has(Capability.Network));
         }
     }
 }

--- a/lizzie/Runtime/Capability.cs
+++ b/lizzie/Runtime/Capability.cs
@@ -10,6 +10,7 @@ namespace lizzie.Runtime
         Async = 1 << 1,
         Random = 1 << 2,
         UnityMainThread = 1 << 3,
-        FileSystem = 1 << 4
+        FileSystem = 1 << 4,
+        Network = 1 << 5
     }
 }

--- a/lizzie/Runtime/RuntimeProfiles.cs
+++ b/lizzie/Runtime/RuntimeProfiles.cs
@@ -50,6 +50,8 @@ namespace lizzie.Runtime
             sandbox.Allow(Capability.Async);
             sandbox.Allow(Capability.Random);
             sandbox.Allow(Capability.FileSystem);
+            if (httpWhitelist != null)
+                sandbox.Allow(Capability.Network);
             var limiter = new DefaultResourceLimiter();
             var ctx = new DefaultScriptContext(
                 scheduler: new DefaultScheduler(),


### PR DESCRIPTION
## Summary
- add `Network` flag to `Capability`
- grant network access in `ServerDefaults` only when an HTTP whitelist is provided
- cover network capability with new tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b9f603bd0c832b8889852f69901294