### PR TITLE
Add HTTP stdlib module and bindings for network access

### DIFF
--- a/lizzie.tests/StdHttpTests.cs
+++ b/lizzie.tests/StdHttpTests.cs
@@ -1,0 +1,114 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+using lizzie.Runtime;
+using HttpModule = lizzie.Std.Http;
+using Xunit;
+
+namespace lizzie.tests
+{
+    public class StdHttpTests
+    {
+        private class TestLimiter : IResourceLimiter
+        {
+            public Capability? Requested { get; private set; }
+            public void Enter() { }
+            public void Exit() { }
+            public void Tick() { }
+            public void Demand(Capability capability) => Requested = capability;
+        }
+
+        private class TestPolicy : INetworkPolicy
+        {
+            private readonly bool _allow;
+            public TestPolicy(bool allow) { _allow = allow; }
+            public bool IsOriginAllowed(Uri origin) => _allow;
+        }
+
+        private static int GetFreePort()
+        {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
+
+        [Fact]
+        public void GetDemandsCapabilityAndRespectsPolicy()
+        {
+            var port = GetFreePort();
+            var url = $"http://localhost:{port}/";
+            using var listener = new HttpListener();
+            listener.Prefixes.Add(url);
+            listener.Start();
+            var handler = Task.Run(async () =>
+            {
+                var ctx = await listener.GetContextAsync();
+                using var writer = new StreamWriter(ctx.Response.OutputStream);
+                await writer.WriteAsync("hello");
+                writer.Flush();
+                ctx.Response.Close();
+            });
+
+            var limiter = new TestLimiter();
+            var policy = new TestPolicy(true);
+            var content = HttpModule.get(url, limiter, policy);
+            handler.Wait();
+            listener.Stop();
+
+            Assert.Equal("hello", content);
+            Assert.Equal(Capability.Network, limiter.Requested);
+        }
+
+        [Fact]
+        public void PostDemandsCapabilityAndRespectsPolicy()
+        {
+            var port = GetFreePort();
+            var url = $"http://localhost:{port}/";
+            using var listener = new HttpListener();
+            listener.Prefixes.Add(url);
+            listener.Start();
+            var handler = Task.Run(async () =>
+            {
+                var ctx = await listener.GetContextAsync();
+                using var reader = new StreamReader(ctx.Request.InputStream);
+                var received = await reader.ReadToEndAsync();
+                var buffer = Encoding.UTF8.GetBytes(received);
+                ctx.Response.OutputStream.Write(buffer, 0, buffer.Length);
+                ctx.Response.Close();
+            });
+
+            var limiter = new TestLimiter();
+            var policy = new TestPolicy(true);
+            var result = HttpModule.post(url, "payload", limiter, policy);
+            handler.Wait();
+            listener.Stop();
+
+            Assert.Equal("payload", result);
+            Assert.Equal(Capability.Network, limiter.Requested);
+        }
+
+        [Fact]
+        public void GetDeniedWhenPolicyRejects()
+        {
+            var limiter = new TestLimiter();
+            var policy = new TestPolicy(false);
+            Assert.Throws<UnauthorizedAccessException>(() => HttpModule.get("http://localhost/", limiter, policy));
+            Assert.Equal(Capability.Network, limiter.Requested);
+        }
+
+        [Fact]
+        public void BindingRegistryProvidesGetAndPost()
+        {
+            var ctx = RuntimeProfiles.ServerDefaults(httpWhitelist: new[] { "https://example.com" });
+            Assert.True(ctx.Bindings.TryGet("get", out var getFn));
+            Assert.IsType<Func<string, string>>(getFn);
+            Assert.True(ctx.Bindings.TryGet("post", out var postFn));
+            Assert.IsType<Func<string, string, string>>(postFn);
+        }
+    }
+}

--- a/lizzie/Runtime/RuntimeProfiles.cs
+++ b/lizzie/Runtime/RuntimeProfiles.cs
@@ -30,6 +30,7 @@ namespace lizzie.Runtime
                 resources: limiter,
                 host: new DefaultHostServices());
             ctx.BindFileModule();
+            ctx.BindHttpModule();
             return ctx;
         }
 
@@ -60,6 +61,7 @@ namespace lizzie.Runtime
                 resources: limiter,
                 host: new DefaultHostServices());
             ctx.BindFileModule();
+            ctx.BindHttpModule();
             return ctx;
         }
 

--- a/lizzie/Runtime/StdBindingExtensions.cs
+++ b/lizzie/Runtime/StdBindingExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using FileModule = lizzie.Std.File;
+using HttpModule = lizzie.Std.Http;
 
 namespace lizzie.Runtime
 {
@@ -21,6 +22,18 @@ namespace lizzie.Runtime
             ctx.Bindings.Bind("listDir", (Func<string, string[]>)(path => FileModule.listDir(path, limiter, fs)));
             ctx.Bindings.Bind("createDir", (Action<string>)(path => FileModule.createDir(path, limiter, fs)));
             ctx.Bindings.Bind("delete", (Action<string>)(path => FileModule.delete(path, limiter, fs)));
+        }
+
+        /// <summary>
+        /// Registers HTTP functions in the provided script context's binding registry.
+        /// </summary>
+        public static void BindHttpModule(this IScriptContext ctx)
+        {
+            if (ctx.Sandbox is not INetworkPolicy net)
+                return;
+            var limiter = ctx.Resources;
+            ctx.Bindings.Bind("get", (Func<string, string>)(url => HttpModule.get(url, limiter, net)));
+            ctx.Bindings.Bind("post", (Func<string, string, string>)((url, body) => HttpModule.post(url, body, limiter, net)));
         }
     }
 }

--- a/lizzie/Std/Http.cs
+++ b/lizzie/Std/Http.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Net.Http;
+using lizzie.Runtime;
+
+namespace lizzie.Std
+{
+    /// <summary>
+    /// HTTP operations exposed to scripts.
+    /// </summary>
+    public static class Http
+    {
+        private static readonly HttpClient _client = new();
+
+        /// <summary>
+        /// Performs an HTTP GET request to the specified URL.
+        /// </summary>
+        public static string get(string url, IResourceLimiter lim, INetworkPolicy policy)
+        {
+            lim.Demand(Capability.Network);
+            var uri = new Uri(url);
+            if (!policy.IsOriginAllowed(uri))
+                throw new UnauthorizedAccessException($"Origin '{uri}' is not allowed.");
+            return _client.GetStringAsync(uri).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Performs an HTTP POST request to the specified URL with the provided body.
+        /// </summary>
+        public static string post(string url, string body, IResourceLimiter lim, INetworkPolicy policy)
+        {
+            lim.Demand(Capability.Network);
+            var uri = new Uri(url);
+            if (!policy.IsOriginAllowed(uri))
+                throw new UnauthorizedAccessException($"Origin '{uri}' is not allowed.");
+            var response = _client.PostAsync(uri, new StringContent(body)).GetAwaiter().GetResult();
+            return response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `Std.Http` with `get` and `post` helpers that demand network capability, check policy, and use `HttpClient`
- expose HTTP helpers via new `BindHttpModule` extension and bind in default runtime profiles
- cover HTTP module with tests for capability, policy, and binding registration

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b9f7167b4c832b88046acb728984c6