### PR TITLE
docs: document HTTP module

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,3 +11,31 @@ declarations using `var(@name, type, value)` and the host memory functions
 `host-var`, `host-set` and `host-del` which allow values to persist across script
 invocations.
 
+## HTTP module
+
+Lizzie ships with an HTTP module exposing simple helpers for making network
+requests from scripts. The module provides `get` and `post` functions that
+perform HTTP GET and POST operations respectively.
+
+```lizzie
+get("https://example.com")
+post("https://example.com/api", "{ 'foo': 42 }")
+```
+
+Using these functions requires the runtime to allow `Capability.Network` and
+to expose an `INetworkPolicy` implementation. The policy is consulted to ensure
+requests are only sent to whitelisted origins.
+
+Runtime profiles such as `RuntimeProfiles.ServerDefaults` accept an HTTP
+whitelist and automatically register the HTTP module:
+
+```csharp
+var ctx = RuntimeProfiles.ServerDefaults(
+    httpWhitelist: new[] { "https://example.com" });
+// ctx exposes the get/post functions and enforces the whitelist
+```
+
+Origins must be specified using the scheme and authority (e.g.
+`https://example.com`). Requests to non-whitelisted origins will throw an
+`UnauthorizedAccessException`.
+

--- a/lizzie/Runtime/RuntimeProfiles.cs
+++ b/lizzie/Runtime/RuntimeProfiles.cs
@@ -14,9 +14,9 @@ namespace lizzie.Runtime
         /// <summary>
         /// Creates a <see cref="IScriptContext"/> with settings suited for the
         /// Unity environment. The returned context enables the
-        /// <see cref="Capability.UnityMainThread"/> capability and installs a
+        /// <see cref="Capability.UnityMainThread"/> capability, installs a
         /// resource limiter that enforces a simple per-frame instruction
-        /// budget.
+        /// budget, and registers the standard file and HTTP modules.
         /// </summary>
         /// <param name="frameBudget">Maximum number of instructions allowed per frame.</param>
         public static IScriptContext UnityDefaults(int frameBudget = 1000)
@@ -37,8 +37,10 @@ namespace lizzie.Runtime
         /// <summary>
         /// Creates a <see cref="IScriptContext"/> configured for a typical
         /// server environment. The context omits the
-        /// <see cref="Capability.UnityMainThread"/> capability and exposes
-        /// read-only HTTP and filesystem whitelists.
+        /// <see cref="Capability.UnityMainThread"/> capability, exposes
+        /// read-only HTTP and filesystem whitelists, and registers the
+        /// standard file and HTTP modules. Supplying an HTTP whitelist enables
+        /// the <see cref="Capability.Network"/> capability.
         /// </summary>
         /// <param name="httpWhitelist">Collection of HTTP origins allowed for requests.</param>
         /// <param name="filesystemWhitelist">Collection of directory paths allowed for file access.</param>


### PR DESCRIPTION
## Summary
- document `Http` module usage with `get`/`post` examples and whitelist configuration
- clarify runtime profiles register standard File and HTTP modules and when `Capability.Network` is enabled

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bab1e46388832b99b9a9df5b64b7ff