### PR TITLE
Add PUT and DELETE helpers to HTTP module

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,12 +14,14 @@ invocations.
 ## HTTP module
 
 Lizzie ships with an HTTP module exposing simple helpers for making network
-requests from scripts. The module provides `get` and `post` functions that
-perform HTTP GET and POST operations respectively.
+requests from scripts. The module provides `get`, `post`, `put` and `deleteUrl`
+functions that perform HTTP GET, POST, PUT and DELETE operations respectively.
 
 ```lizzie
 get("https://example.com")
 post("https://example.com/api", "{ 'foo': 42 }")
+put("https://example.com/api/1", "{ 'foo': 43 }")
+deleteUrl("https://example.com/api/1")
 ```
 
 Using these functions requires the runtime to allow `Capability.Network` and
@@ -32,7 +34,7 @@ whitelist and automatically register the HTTP module:
 ```csharp
 var ctx = RuntimeProfiles.ServerDefaults(
     httpWhitelist: new[] { "https://example.com" });
-// ctx exposes the get/post functions and enforces the whitelist
+// ctx exposes the HTTP functions and enforces the whitelist
 ```
 
 Origins must be specified using the scheme and authority (e.g.

--- a/lizzie/Runtime/StdBindingExtensions.cs
+++ b/lizzie/Runtime/StdBindingExtensions.cs
@@ -34,6 +34,8 @@ namespace lizzie.Runtime
             var limiter = ctx.Resources;
             ctx.Bindings.Bind("get", (Func<string, string>)(url => HttpModule.get(url, limiter, net)));
             ctx.Bindings.Bind("post", (Func<string, string, string>)((url, body) => HttpModule.post(url, body, limiter, net)));
+            ctx.Bindings.Bind("put", (Func<string, string, string>)((url, body) => HttpModule.put(url, body, limiter, net)));
+            ctx.Bindings.Bind("deleteUrl", (Func<string, string>)(url => HttpModule.delete(url, limiter, net)));
         }
     }
 }

--- a/lizzie/Std/Http.cs
+++ b/lizzie/Std/Http.cs
@@ -35,5 +35,31 @@ namespace lizzie.Std
             var response = _client.PostAsync(uri, new StringContent(body)).GetAwaiter().GetResult();
             return response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
         }
+
+        /// <summary>
+        /// Performs an HTTP PUT request to the specified URL with the provided body.
+        /// </summary>
+        public static string put(string url, string body, IResourceLimiter lim, INetworkPolicy policy)
+        {
+            lim.Demand(Capability.Network);
+            var uri = new Uri(url);
+            if (!policy.IsOriginAllowed(uri))
+                throw new UnauthorizedAccessException($"Origin '{uri}' is not allowed.");
+            var response = _client.PutAsync(uri, new StringContent(body)).GetAwaiter().GetResult();
+            return response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Performs an HTTP DELETE request to the specified URL.
+        /// </summary>
+        public static string delete(string url, IResourceLimiter lim, INetworkPolicy policy)
+        {
+            lim.Demand(Capability.Network);
+            var uri = new Uri(url);
+            if (!policy.IsOriginAllowed(uri))
+                throw new UnauthorizedAccessException($"Origin '{uri}' is not allowed.");
+            var response = _client.DeleteAsync(uri).GetAwaiter().GetResult();
+            return response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- extend HTTP standard library with `put` and `delete` helpers
- expose new HTTP helpers through runtime binding registry
- document usage of the new network helpers

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bc4bafedd8832bbe1b9221e85db4ca